### PR TITLE
fix u254 double test overflow

### DIFF
--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -293,6 +293,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
 #[cfg(test)]
 mod tests {
+    use crate::circuits::bigint::utils::biguint_two_pow_254;
     use crate::circuits::bigint::{
         U254,
         utils::{biguint_from_bits, biguint_from_wires, random_u254, wires_set_from_u254},
@@ -378,7 +379,7 @@ mod tests {
             gate.evaluate();
         }
         let c = biguint_from_wires(circuit.0);
-        assert_eq!(c, a.clone() + a.clone());
+        assert_eq!(c, (a.clone() + a.clone()) % biguint_two_pow_254());
     }
 
     #[test]

--- a/src/circuits/bigint/utils.rs
+++ b/src/circuits/bigint/utils.rs
@@ -2,15 +2,23 @@ use super::U254;
 use crate::bag::*;
 use num_bigint::BigUint;
 use rand::{Rng, rng};
-use std::str::FromStr;
+// Constant byte array representing 2^254
+const TWO_POW_254_BYTES_LE: [u8; 32] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x40,
+];
+
+#[inline(always)]
+pub fn biguint_two_pow_254() -> BigUint {
+    BigUint::from_bytes_le(&TWO_POW_254_BYTES_LE)
+}
 
 pub fn random_biguint() -> BigUint {
     BigUint::from_bytes_le(&rng().random::<[u8; 32]>())
 }
 
 pub fn random_u254() -> BigUint {
-    BigUint::from_bytes_le(&rand::rng().random::<[u8; 32]>())
-        % BigUint::from_str("2").unwrap().pow(254)
+    BigUint::from_bytes_le(&rand::rng().random::<[u8; 32]>()) % biguint_two_pow_254()
 }
 
 pub fn bits_from_biguint(u: BigUint) -> Vec<bool> {


### PR DESCRIPTION
There exists an overflow in test_double when random a bigger than 2^253.  