### PR TITLE
Optimize Montgomery Multiplications and Fix Some Bugs in bigint

### DIFF
--- a/src/circuits/basic.rs
+++ b/src/circuits/basic.rs
@@ -1,19 +1,19 @@
 use crate::bag::*;
 
 pub fn half_adder(a: Wirex, b: Wirex) -> Circuit {
-    let result = Rc::new(RefCell::new(Wire::new()));
-    let carry = Rc::new(RefCell::new(Wire::new()));
+    let result = new_wirex();
+    let carry = new_wirex();
     let gate_result = Gate::xor(a.clone(), b.clone(), result.clone());
     let gate_carry = Gate::and(a.clone(), b.clone(), carry.clone());
     Circuit::new(vec![result, carry], vec![gate_result, gate_carry])
 }
 
 pub fn full_adder(a: Wirex, b: Wirex, c: Wirex) -> Circuit {
-    let d = Rc::new(RefCell::new(Wire::new()));
-    let e = Rc::new(RefCell::new(Wire::new()));
-    let f = Rc::new(RefCell::new(Wire::new()));
-    let result = Rc::new(RefCell::new(Wire::new()));
-    let carry = Rc::new(RefCell::new(Wire::new()));
+    let d = new_wirex();
+    let e = new_wirex();
+    let f = new_wirex();
+    let result = new_wirex();
+    let carry = new_wirex();
     let gate_1 = Gate::xor(a.clone(), b.clone(), d.clone());
     let gate_2 = Gate::and(a.clone(), b.clone(), e.clone());
     let gate_3 = Gate::xor(d.clone(), c.clone(), result.clone());
@@ -26,9 +26,9 @@ pub fn full_adder(a: Wirex, b: Wirex, c: Wirex) -> Circuit {
 }
 
 pub fn half_subtracter(a: Wirex, b: Wirex) -> Circuit {
-    let result = Rc::new(RefCell::new(Wire::new()));
-    let borrow = Rc::new(RefCell::new(Wire::new()));
-    let not_a = Rc::new(RefCell::new(Wire::new()));
+    let result = new_wirex();
+    let borrow = new_wirex();
+    let not_a = new_wirex();
     let gate_not_a = Gate::not(a.clone(), not_a.clone());
     let gate_result = Gate::xor(a.clone(), b.clone(), result.clone());
     let gate_borrow = Gate::and(not_a.clone(), b.clone(), borrow.clone());
@@ -39,13 +39,13 @@ pub fn half_subtracter(a: Wirex, b: Wirex) -> Circuit {
 }
 
 pub fn full_subtracter(a: Wirex, b: Wirex, c: Wirex) -> Circuit {
-    let d = Rc::new(RefCell::new(Wire::new()));
-    let e = Rc::new(RefCell::new(Wire::new()));
-    let f = Rc::new(RefCell::new(Wire::new()));
-    let g = Rc::new(RefCell::new(Wire::new()));
-    let h = Rc::new(RefCell::new(Wire::new()));
-    let result = Rc::new(RefCell::new(Wire::new()));
-    let borrow = Rc::new(RefCell::new(Wire::new()));
+    let d = new_wirex();
+    let e = new_wirex();
+    let f = new_wirex();
+    let g = new_wirex();
+    let h = new_wirex();
+    let result = new_wirex();
+    let borrow = new_wirex();
 
     let gate_1 = Gate::xor(a.clone(), b.clone(), d.clone());
     let gate_2 = Gate::xor(c.clone(), d.clone(), result.clone());
@@ -62,10 +62,10 @@ pub fn full_subtracter(a: Wirex, b: Wirex, c: Wirex) -> Circuit {
 }
 
 pub fn selector(a: Wirex, b: Wirex, c: Wirex) -> Circuit {
-    let d = Rc::new(RefCell::new(Wire::new()));
-    let e = Rc::new(RefCell::new(Wire::new()));
-    let f = Rc::new(RefCell::new(Wire::new()));
-    let g = Rc::new(RefCell::new(Wire::new()));
+    let d = new_wirex();
+    let e = new_wirex();
+    let f = new_wirex();
+    let g = new_wirex();
     let gate_1 = Gate::not(c.clone(), e.clone());
     let gate_2 = Gate::nand(a.clone(), c.clone(), d.clone());
     let gate_3 = Gate::nand(e.clone(), b.clone(), f.clone());
@@ -120,10 +120,10 @@ mod tests {
         ];
 
         for ((a, b), (c, d)) in result {
-            let a_wire = Rc::new(RefCell::new(Wire::new()));
+            let a_wire = new_wirex();
             a_wire.borrow_mut().set(a);
 
-            let b_wire = Rc::new(RefCell::new(Wire::new()));
+            let b_wire = new_wirex();
             b_wire.borrow_mut().set(b);
 
             let circuit = half_adder(a_wire, b_wire);
@@ -153,13 +153,13 @@ mod tests {
         ];
 
         for ((a, b, c), (d, e)) in result {
-            let a_wire = Rc::new(RefCell::new(Wire::new()));
+            let a_wire = new_wirex();
             a_wire.borrow_mut().set(a);
 
-            let b_wire = Rc::new(RefCell::new(Wire::new()));
+            let b_wire = new_wirex();
             b_wire.borrow_mut().set(b);
 
-            let c_wire = Rc::new(RefCell::new(Wire::new()));
+            let c_wire = new_wirex();
             c_wire.borrow_mut().set(c);
 
             let circuit = full_adder(a_wire, b_wire, c_wire);
@@ -185,10 +185,10 @@ mod tests {
         ];
 
         for ((a, b), (c, d)) in result {
-            let a_wire = Rc::new(RefCell::new(Wire::new()));
+            let a_wire = new_wirex();
             a_wire.borrow_mut().set(a);
 
-            let b_wire = Rc::new(RefCell::new(Wire::new()));
+            let b_wire = new_wirex();
             b_wire.borrow_mut().set(b);
 
             let circuit = half_subtracter(a_wire, b_wire);
@@ -218,13 +218,13 @@ mod tests {
         ];
 
         for ((a, b, c), (d, e)) in result {
-            let a_wire = Rc::new(RefCell::new(Wire::new()));
+            let a_wire = new_wirex();
             a_wire.borrow_mut().set(a);
 
-            let b_wire = Rc::new(RefCell::new(Wire::new()));
+            let b_wire = new_wirex();
             b_wire.borrow_mut().set(b);
 
-            let c_wire = Rc::new(RefCell::new(Wire::new()));
+            let c_wire = new_wirex();
             c_wire.borrow_mut().set(c);
 
             let circuit = full_subtracter(a_wire, b_wire, c_wire);
@@ -254,13 +254,13 @@ mod tests {
         ];
 
         for ((a, b, c), d) in result {
-            let a_wire = Rc::new(RefCell::new(Wire::new()));
+            let a_wire = new_wirex();
             a_wire.borrow_mut().set(a);
 
-            let b_wire = Rc::new(RefCell::new(Wire::new()));
+            let b_wire = new_wirex();
             b_wire.borrow_mut().set(b);
 
-            let c_wire = Rc::new(RefCell::new(Wire::new()));
+            let c_wire = new_wirex();
             c_wire.borrow_mut().set(c);
 
             let circuit = selector(a_wire, b_wire, c_wire);
@@ -279,8 +279,8 @@ mod tests {
     fn test_multiplexer() {
         let w = 5;
         let n = 2_usize.pow(w as u32);
-        let a: Wires = (0..n).map(|_| Rc::new(RefCell::new(Wire::new()))).collect();
-        let s: Wires = (0..w).map(|_| Rc::new(RefCell::new(Wire::new()))).collect();
+        let a: Wires = (0..n).map(|_| new_wirex()).collect();
+        let s: Wires = (0..w).map(|_| new_wirex()).collect();
 
         for wire in a.clone() {
             wire.borrow_mut().set(rng().random());

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -3,7 +3,7 @@ use crate::{
     bag::*,
     circuits::{
         basic::{full_adder, full_subtracter, half_adder, half_subtracter},
-        bigint::utils::{bits_from_biguint, wires_for_u254},
+        bigint::utils::bits_from_biguint,
     },
 };
 use num_bigint::BigUint;
@@ -32,7 +32,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
         let b_bits = bits_from_biguint(b);
 
-        let mut carry = Rc::new(RefCell::new(Wire::new()));
+        let mut carry = new_wirex();
         let mut first_one = 0;
         while !b_bits[first_one] {
             first_one += 1;
@@ -42,20 +42,20 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
             if i < first_one {
                 circuit.add_wire(a[i].clone());
             } else if i == first_one {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 circuit.add(Gate::not(a[i].clone(), wire.clone()));
                 circuit.add_wire(wire);
                 carry = a[i].clone();
             } else if b_bits[i] {
-                let wire_1 = Rc::new(RefCell::new(Wire::new()));
-                let wire_2 = Rc::new(RefCell::new(Wire::new()));
+                let wire_1 = new_wirex();
+                let wire_2 = new_wirex();
                 circuit.add(Gate::xnor(a[i].clone(), carry.clone(), wire_1.clone()));
                 circuit.add(Gate::or(a[i].clone(), carry.clone(), wire_2.clone()));
                 circuit.add_wire(wire_1);
                 carry = wire_2;
             } else {
-                let wire_1 = Rc::new(RefCell::new(Wire::new()));
-                let wire_2 = Rc::new(RefCell::new(Wire::new()));
+                let wire_1 = new_wirex();
+                let wire_2 = new_wirex();
                 circuit.add(Gate::xor(a[i].clone(), carry.clone(), wire_1.clone()));
                 circuit.add(Gate::and(a[i].clone(), carry.clone(), wire_2.clone()));
                 circuit.add_wire(wire_1);
@@ -88,7 +88,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
         let b_bits = bits_from_biguint(b);
 
-        let mut carry = Rc::new(RefCell::new(Wire::new()));
+        let mut carry = new_wirex();
         let mut first_one = 0;
         while !b_bits[first_one] {
             first_one += 1;
@@ -98,20 +98,20 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
             if i < first_one {
                 circuit.add_wire(a[i].clone());
             } else if i == first_one {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 circuit.add(Gate::not(a[i].clone(), wire.clone()));
                 circuit.add_wire(wire);
                 carry = a[i].clone();
             } else if b_bits[i] {
-                let wire_1 = Rc::new(RefCell::new(Wire::new()));
-                let wire_2 = Rc::new(RefCell::new(Wire::new()));
+                let wire_1 = new_wirex();
+                let wire_2 = new_wirex();
                 circuit.add(Gate::xnor(a[i].clone(), carry.clone(), wire_1.clone()));
                 circuit.add(Gate::or(a[i].clone(), carry.clone(), wire_2.clone()));
                 circuit.add_wire(wire_1);
                 carry = wire_2;
             } else {
-                let wire_1 = Rc::new(RefCell::new(Wire::new()));
-                let wire_2 = Rc::new(RefCell::new(Wire::new()));
+                let wire_1 = new_wirex();
+                let wire_2 = new_wirex();
                 circuit.add(Gate::xor(a[i].clone(), carry.clone(), wire_1.clone()));
                 circuit.add(Gate::and(a[i].clone(), carry.clone(), wire_2.clone()));
                 circuit.add_wire(wire_1);
@@ -155,8 +155,8 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
     pub fn double(a: Wires) -> Circuit {
         assert_eq!(a.len(), N_BITS);
         let mut circuit = Circuit::empty();
-        let not_a = Rc::new(RefCell::new(Wire::new()));
-        let zero_wire = Rc::new(RefCell::new(Wire::new()));
+        let not_a = new_wirex();
+        let zero_wire = new_wirex();
         circuit.add(Gate::not(a[0].clone(), not_a.clone()));
         circuit.add(Gate::and(a[0].clone(), not_a.clone(), zero_wire.clone()));
         circuit.add_wire(zero_wire);
@@ -167,8 +167,8 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
     pub fn half(a: Wires) -> Circuit {
         assert_eq!(a.len(), N_BITS);
         let mut circuit = Circuit::empty();
-        let not_a = Rc::new(RefCell::new(Wire::new()));
-        let zero_wire = Rc::new(RefCell::new(Wire::new()));
+        let not_a = new_wirex();
+        let zero_wire = new_wirex();
         circuit.add(Gate::not(a[0].clone(), not_a.clone()));
         circuit.add(Gate::and(a[0].clone(), not_a.clone(), zero_wire.clone()));
         circuit.add_wires(a[1..N_BITS].to_vec());
@@ -179,8 +179,8 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
     pub fn odd_part(a: Wires) -> Circuit {
         assert_eq!(a.len(), N_BITS);
         let mut circuit = Circuit::empty();
-        let mut select = wires_for_u254();
-        let not_select = wires_for_u254();
+        let mut select = Self::wires();
+        let not_select = Self::wires();
         select[0] = a[0].clone();
         for i in 1..N_BITS {
             circuit.add(Gate::or(
@@ -194,7 +194,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
             circuit.add(Gate::not(select[i].clone(), not_select[i].clone()));
         }
 
-        let mut k = wires_for_u254();
+        let mut k = Self::wires();
         k[0] = a[0].clone();
         for i in 1..N_BITS {
             circuit.add(Gate::and(
@@ -231,11 +231,11 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
         let mut circuit = Circuit::empty();
 
-        let mut want: Rc<RefCell<Wire>> = Rc::new(RefCell::new(Wire::new()));
+        let mut want: Rc<RefCell<Wire>> = new_wirex();
         for i in 0..N_BITS {
-            circuit.add_wire(Rc::new(RefCell::new(Wire::new())));
+            circuit.add_wire(new_wirex());
             if i > 0 {
-                let subtract_bit = Rc::new(RefCell::new(Wire::new()));
+                let subtract_bit = new_wirex();
                 circuit.add(Gate::xor(
                     want.clone(),
                     b_wires[i].clone(),
@@ -246,9 +246,9 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
                     a_wires[i].clone(),
                     circuit.0[i].clone(),
                 ));
-                let new_want_or0 = Rc::new(RefCell::new(Wire::new()));
-                let new_want_or1 = Rc::new(RefCell::new(Wire::new()));
-                let new_want = Rc::new(RefCell::new(Wire::new()));
+                let new_want_or0 = new_wirex();
+                let new_want_or1 = new_wirex();
+                let new_want = new_wirex();
                 circuit.add(Gate::nimp(
                     subtract_bit.clone(),
                     a_wires[i].clone(),
@@ -271,7 +271,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
                     a_wires[i].clone(),
                     circuit.0[i].clone(),
                 ));
-                let new_want: Rc<RefCell<Wire>> = Rc::new(RefCell::new(Wire::new()));
+                let new_want: Rc<RefCell<Wire>> = new_wirex();
                 circuit.add(Gate::nimp(
                     b_wires[i].clone(),
                     a_wires[i].clone(),
@@ -282,7 +282,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         }
 
         if check_bound {
-            let bound_check_wire = Rc::new(RefCell::new(Wire::new()));
+            let bound_check_wire = new_wirex();
             circuit.add(Gate::not(want.clone(), bound_check_wire.clone()));
             circuit.add_wire(bound_check_wire);
         }
@@ -294,20 +294,16 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 #[cfg(test)]
 mod tests {
     use crate::circuits::bigint::{
-        U254,
-        utils::{biguint_from_bits, biguint_from_wires, random_u254, wires_set_from_u254},
+        utils::{biguint_from_bits, biguint_from_wires, biguint_two_pow_254, random_biguint_n_bits}, U254
     };
     use num_bigint::BigUint;
     use std::str::FromStr;
 
     #[test]
     fn test_add() {
-        let a = random_u254();
-        let b = random_u254();
-        let circuit = U254::add(
-            wires_set_from_u254(a.clone()),
-            wires_set_from_u254(b.clone()),
-        );
+        let a = random_biguint_n_bits(254);
+        let b = random_biguint_n_bits(254);
+        let circuit = U254::add(U254::wires_set_from_number(a.clone()), U254::wires_set_from_number(b.clone()));
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -318,9 +314,9 @@ mod tests {
 
     #[test]
     fn test_add_constant() {
-        let a = random_u254();
-        let b = random_u254();
-        let circuit = U254::add_constant(wires_set_from_u254(a.clone()), b.clone());
+        let a = random_biguint_n_bits(254);
+        let b = random_biguint_n_bits(254);
+        let circuit = U254::add_constant(U254::wires_set_from_number(a.clone()), b.clone());
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -331,11 +327,11 @@ mod tests {
 
     #[test]
     fn test_add_without_carry() {
-        let a = random_u254();
-        let b = random_u254();
+        let a = random_biguint_n_bits(254);
+        let b = random_biguint_n_bits(254);
         let circuit = U254::add_without_carry(
-            wires_set_from_u254(a.clone()),
-            wires_set_from_u254(b.clone()),
+            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -352,14 +348,14 @@ mod tests {
 
     #[test]
     fn test_sub() {
-        let mut a = random_u254();
-        let mut b = random_u254();
+        let mut a = random_biguint_n_bits(254);
+        let mut b = random_biguint_n_bits(254);
         if a < b {
             (a, b) = (b, a);
         }
         let circuit = U254::sub(
-            wires_set_from_u254(a.clone()),
-            wires_set_from_u254(b.clone()),
+            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -371,20 +367,20 @@ mod tests {
 
     #[test]
     fn test_double() {
-        let a = random_u254();
-        let circuit = U254::double(wires_set_from_u254(a.clone()));
+        let a = random_biguint_n_bits(254);
+        let circuit = U254::double(U254::wires_set_from_number(a.clone()));
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
         }
         let c = biguint_from_wires(circuit.0);
-        assert_eq!(c, a.clone() + a.clone());
+        assert_eq!(c, (a.clone() + a.clone()) % biguint_two_pow_254());    
     }
 
     #[test]
     fn test_half() {
-        let a = random_u254();
-        let circuit = U254::half(wires_set_from_u254(a.clone()));
+        let a = random_biguint_n_bits(254);
+        let circuit = U254::half(U254::wires_set_from_number(a.clone()));
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -396,8 +392,8 @@ mod tests {
 
     #[test]
     fn test_odd_part() {
-        let a = random_u254();
-        let circuit = U254::odd_part(wires_set_from_u254(a.clone()));
+        let a = random_biguint_n_bits(254);
+        let circuit = U254::odd_part(U254::wires_set_from_number(a.clone()));
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -410,11 +406,11 @@ mod tests {
     #[test]
     fn test_optimized_sub() {
         for _ in 0..10 {
-            let a = random_u254();
-            let b = random_u254();
+            let a = random_biguint_n_bits(254);
+            let b = random_biguint_n_bits(254);
             let mut circuit = U254::optimized_sub(
-                wires_set_from_u254(a.clone()),
-                wires_set_from_u254(b.clone()),
+                U254::wires_set_from_number(a.clone()),
+                U254::wires_set_from_number(b.clone()),
                 true,
             );
             circuit.gate_counts().print();

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -25,6 +25,22 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         circuit
     }
 
+    pub fn add_generic(a: Wires, b: Wires, len: usize) -> Circuit {
+        assert_eq!(a.len(), len);
+        assert_eq!(b.len(), len);
+        let mut circuit = Circuit::empty();
+        let wires = circuit.extend(half_adder(a[0].clone(), b[0].clone()));
+        circuit.add_wire(wires[0].clone());
+        let mut carry = wires[1].clone();
+        for i in 1..len {
+            let wires = circuit.extend(full_adder(a[i].clone(), b[i].clone(), carry));
+            circuit.add_wire(wires[0].clone());
+            carry = wires[1].clone();
+        }
+        circuit.add_wire(carry);
+        circuit
+    }
+
     pub fn add_constant(a: Wires, b: BigUint) -> Circuit {
         assert_eq!(a.len(), N_BITS);
         assert_ne!(b, BigUint::ZERO);

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -310,7 +310,10 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 #[cfg(test)]
 mod tests {
     use crate::circuits::bigint::{
-        utils::{biguint_from_bits, biguint_from_wires, biguint_two_pow_254, random_biguint_n_bits}, U254
+        U254,
+        utils::{
+            biguint_from_bits, biguint_from_wires, biguint_two_pow_254, random_biguint_n_bits,
+        },
     };
     use num_bigint::BigUint;
     use std::str::FromStr;
@@ -319,7 +322,10 @@ mod tests {
     fn test_add() {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
-        let circuit = U254::add(U254::wires_set_from_number(a.clone()), U254::wires_set_from_number(b.clone()));
+        let circuit = U254::add(
+            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(b.clone()),
+        );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -390,7 +396,7 @@ mod tests {
             gate.evaluate();
         }
         let c = biguint_from_wires(circuit.0);
-        assert_eq!(c, (a.clone() + a.clone()) % biguint_two_pow_254());    
+        assert_eq!(c, (a.clone() + a.clone()) % biguint_two_pow_254());
     }
 
     #[test]

--- a/src/circuits/bigint/cmp.rs
+++ b/src/circuits/bigint/cmp.rs
@@ -1,7 +1,6 @@
 use super::BigIntImpl;
 use crate::circuits::basic::multiplexer;
-use crate::circuits::bigint::U254;
-use crate::circuits::bigint::utils::{bits_from_biguint, wires_for_u254};
+use crate::circuits::bigint::utils::bits_from_biguint;
 use crate::{bag::*, circuits::basic::selector};
 use num_bigint::BigUint;
 
@@ -11,11 +10,11 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         assert_eq!(b.len(), Self::N_BITS);
         let mut circuit = Circuit::empty();
 
-        let c = wires_for_u254();
+        let c = Self::wires();
         for i in 0..N_BITS {
             circuit.add(Gate::xor(a[i].clone(), b[i].clone(), c[i].clone()));
         }
-        let result = circuit.extend(U254::equal_constant(c, BigUint::ZERO));
+        let result = circuit.extend(Self::equal_constant(c, BigUint::ZERO));
         circuit.add_wires(result);
         circuit
     }
@@ -27,7 +26,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         let b_bits = bits_from_biguint(b);
         let mut output = a[0].clone();
         if !b_bits[0] {
-            let not_a0 = Rc::new(RefCell::new(Wire::new()));
+            let not_a0 = new_wirex();
             circuit.add(Gate::not(a[0].clone(), not_a0.clone()));
             output = not_a0;
         }
@@ -35,11 +34,11 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         for i in 1..N_BITS {
             let mut a_or_a_not = a[i].clone();
             if !b_bits[i] {
-                let not_ai = Rc::new(RefCell::new(Wire::new()));
+                let not_ai = new_wirex();
                 circuit.add(Gate::not(a[i].clone(), not_ai.clone()));
                 a_or_a_not = not_ai;
             }
-            let new_output = Rc::new(RefCell::new(Wire::new()));
+            let new_output = new_wirex();
             circuit.add(Gate::and(
                 output.clone(),
                 a_or_a_not.clone(),
@@ -56,13 +55,13 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         assert_eq!(b.len(), N_BITS);
         let mut circuit = Circuit::empty();
 
-        let not_b = wires_for_u254();
+        let not_b = Self::wires();
 
         for i in 0..N_BITS {
             circuit.add(Gate::not(b[i].clone(), not_b[i].clone()));
         }
 
-        let wires = circuit.extend(U254::add(a, not_b));
+        let wires = circuit.extend(Self::add(a, not_b));
         circuit.add_wire(wires[N_BITS].clone());
         circuit
     }
@@ -71,13 +70,13 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         assert_eq!(a.len(), N_BITS);
         let mut circuit = Circuit::empty();
 
-        let not_a = wires_for_u254();
+        let not_a = Self::wires();
 
         for i in 0..N_BITS {
             circuit.add(Gate::not(a[i].clone(), not_a[i].clone()));
         }
 
-        let wires = circuit.extend(U254::add_constant(not_a, b));
+        let wires = circuit.extend(Self::add_constant(not_a, b));
         circuit.add_wire(wires[N_BITS].clone());
         circuit
     }
@@ -100,7 +99,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
         let mut result = vec![];
         for i in 0..Self::N_BITS {
-            result.push(Rc::new(RefCell::new(Wire::new())));
+            result.push(new_wirex());
             circuit.add(Gate::and(a[i].clone(), s.clone(), result[i].clone()));
         }
         circuit.add_wires(result);
@@ -112,7 +111,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         let mut bits = bits_from_biguint(a);
         bits.resize(Self::N_BITS, false);
         for i in 0..Self::N_BITS {
-            bit_wires.push(Rc::new(RefCell::new(Wire::new())));
+            bit_wires.push(new_wirex());
             bit_wires[i].borrow_mut().set(bits[i]);
         }
         Self::self_or_zero(bit_wires, s)
@@ -144,17 +143,16 @@ mod tests {
 
     use super::*;
     use crate::circuits::bigint::{
-        U254,
-        utils::{biguint_from_wires, random_u254, wires_set_from_u254},
+        utils::{biguint_from_wires, random_biguint_n_bits}, U254
     };
 
     #[test]
     fn test_equal_and_equal_constant() {
-        let a = random_u254();
-        let b = random_u254();
+        let a = random_biguint_n_bits(254);
+        let b = random_biguint_n_bits(254);
         let circuit = U254::equal(
-            wires_set_from_u254(a.clone()),
-            wires_set_from_u254(b.clone()),
+            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -162,10 +160,10 @@ mod tests {
         }
         assert_eq!(a == b, circuit.0[0].borrow().get_value());
 
-        let a = random_u254();
+        let a = random_biguint_n_bits(254);
         let circuit = U254::equal(
-            wires_set_from_u254(a.clone()),
-            wires_set_from_u254(a.clone()),
+            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(a.clone()),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -173,8 +171,8 @@ mod tests {
         }
         assert!(circuit.0[0].borrow().get_value());
 
-        let a = random_u254();
-        let circuit = U254::equal_constant(wires_set_from_u254(a.clone()), b.clone());
+        let a = random_biguint_n_bits(254);
+        let circuit = U254::equal_constant(U254::wires_set_from_number(a.clone()), b.clone());
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -184,11 +182,11 @@ mod tests {
 
     #[test]
     fn test_greater_than() {
-        let a = random_u254();
-        let b = random_u254();
+        let a = random_biguint_n_bits(254);
+        let b = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
-            wires_set_from_u254(a.clone()),
-            wires_set_from_u254(b.clone()),
+            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -196,10 +194,10 @@ mod tests {
         }
         assert_eq!(a > b, circuit.0[0].borrow().get_value());
 
-        let a = random_u254();
+        let a = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
-            wires_set_from_u254(a.clone()),
-            wires_set_from_u254(a.clone()),
+            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(a.clone()),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -207,10 +205,10 @@ mod tests {
         }
         assert!(!circuit.0[0].borrow().get_value());
 
-        let a = random_u254();
+        let a = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
-            wires_set_from_u254(a.clone() + BigUint::from_str("1").unwrap()),
-            wires_set_from_u254(a.clone()),
+            U254::wires_set_from_number(a.clone() + BigUint::from_str("1").unwrap()),
+            U254::wires_set_from_number(a.clone()),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -221,9 +219,9 @@ mod tests {
 
     #[test]
     fn test_less_than_constant() {
-        let a = random_u254();
-        let b = random_u254();
-        let circuit = U254::less_than_constant(wires_set_from_u254(a.clone()), b.clone());
+        let a = random_biguint_n_bits(254);
+        let b = random_biguint_n_bits(254);
+        let circuit = U254::less_than_constant(U254::wires_set_from_number(a.clone()), b.clone());
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -233,13 +231,13 @@ mod tests {
 
     #[test]
     fn test_select() {
-        let a = random_u254();
-        let b = random_u254();
-        let s = Rc::new(RefCell::new(Wire::new()));
+        let a = random_biguint_n_bits(254);
+        let b = random_biguint_n_bits(254);
+        let s = new_wirex();
         s.borrow_mut().set(true);
         let circuit = U254::select(
-            wires_set_from_u254(a.clone()),
-            wires_set_from_u254(b.clone()),
+            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(b.clone()),
             s,
         );
         circuit.gate_counts().print();
@@ -252,11 +250,11 @@ mod tests {
 
     #[test]
     fn test_self_or_zero() {
-        let a = random_u254();
+        let a = random_biguint_n_bits(254);
 
-        let s = Rc::new(RefCell::new(Wire::new()));
+        let s = new_wirex();
         s.borrow_mut().set(true);
-        let circuit = U254::self_or_zero(wires_set_from_u254(a.clone()), s);
+        let circuit = U254::self_or_zero(U254::wires_set_from_number(a.clone()), s);
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -264,9 +262,9 @@ mod tests {
         let c = biguint_from_wires(circuit.0);
         assert_eq!(a, c);
 
-        let s = Rc::new(RefCell::new(Wire::new()));
+        let s = new_wirex();
         s.borrow_mut().set(false);
-        let circuit = U254::self_or_zero(wires_set_from_u254(a.clone()), s);
+        let circuit = U254::self_or_zero(U254::wires_set_from_number(a.clone()), s);
         for mut gate in circuit.1 {
             gate.evaluate();
         }
@@ -278,12 +276,12 @@ mod tests {
     fn test_multiplexer() {
         let w = 5;
         let n = 2_usize.pow(w as u32);
-        let a: Vec<BigUint> = (0..n).map(|_| random_u254()).collect();
-        let s: Wires = (0..w).map(|_| Rc::new(RefCell::new(Wire::new()))).collect();
+        let a: Vec<BigUint> = (0..n).map(|_| random_biguint_n_bits(254)).collect();
+        let s: Wires = (0..w).map(|_| new_wirex()).collect();
 
         let mut a_wires = Vec::new();
         for e in a.clone() {
-            a_wires.push(wires_set_from_u254(e));
+            a_wires.push(U254::wires_set_from_number(e));
         }
 
         let mut u = 0;

--- a/src/circuits/bigint/cmp.rs
+++ b/src/circuits/bigint/cmp.rs
@@ -143,7 +143,8 @@ mod tests {
 
     use super::*;
     use crate::circuits::bigint::{
-        utils::{biguint_from_wires, random_biguint_n_bits}, U254
+        U254,
+        utils::{biguint_from_wires, random_biguint_n_bits},
     };
 
     #[test]

--- a/src/circuits/bigint/mod.rs
+++ b/src/circuits/bigint/mod.rs
@@ -1,3 +1,8 @@
+use crate::{
+    bag::*,
+    circuits::bigint::utils::{bits_from_biguint, n_wires},
+};
+use num_bigint::BigUint;
 pub mod add;
 pub mod cmp;
 pub mod mul;
@@ -8,7 +13,19 @@ pub struct BigIntImpl<const N_BITS: usize> {}
 
 impl<const N_BITS: usize> BigIntImpl<N_BITS> {
     pub const N_BITS: usize = N_BITS;
+    pub fn wires() -> Wires {
+        n_wires(N_BITS)
+    }
+    pub fn wires_set_from_number(u: BigUint) -> Wires {
+        bits_from_biguint(u)[0..N_BITS]
+            .iter()
+            .map(|bit| {
+                let wire = new_wirex();
+                wire.borrow_mut().set(*bit);
+                wire
+            })
+            .collect()
+    }
 }
 
 pub type U254 = BigIntImpl<254>;
-pub type U508 = BigIntImpl<508>;

--- a/src/circuits/bigint/mul.rs
+++ b/src/circuits/bigint/mul.rs
@@ -78,7 +78,11 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         circuit
     }
 
-       pub fn mul_by_constant_modulo_power_two(a_wires: Vec<Rc<RefCell<Wire>>>, c: BigUint, power: usize) -> Circuit {
+    pub fn mul_by_constant_modulo_power_two(
+        a_wires: Vec<Rc<RefCell<Wire>>>,
+        c: BigUint,
+        power: usize,
+    ) -> Circuit {
         assert_eq!(a_wires.len(), N_BITS);
         assert!(power < 2 * N_BITS);
         let mut c_bits = bits_from_biguint(c);
@@ -102,13 +106,16 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
                 for j in i..(i + number_of_bits) {
                     addition_wires.push(circuit.0[j].clone());
                 }
-                let new_bits = circuit.extend(Self::add_generic(a_wires[0..number_of_bits].to_vec(), addition_wires, number_of_bits));
+                let new_bits = circuit.extend(Self::add_generic(
+                    a_wires[0..number_of_bits].to_vec(),
+                    addition_wires,
+                    number_of_bits,
+                ));
                 if i + number_of_bits < power {
-                    circuit.0[i..(i + number_of_bits + 1)]
-                    .clone_from_slice(&new_bits);
+                    circuit.0[i..(i + number_of_bits + 1)].clone_from_slice(&new_bits);
                 } else {
-                     circuit.0[i..(i + number_of_bits)]
-                    .clone_from_slice(&new_bits[..number_of_bits]);
+                    circuit.0[i..(i + number_of_bits)]
+                        .clone_from_slice(&new_bits[..number_of_bits]);
                 }
             }
         }
@@ -123,7 +130,8 @@ mod tests {
     use num_bigint::BigUint;
 
     use crate::circuits::bigint::{
-        utils::{biguint_from_bits, random_biguint_n_bits}, U254
+        U254,
+        utils::{biguint_from_bits, random_biguint_n_bits},
     };
 
     //tests are currently only for 254 bits
@@ -181,11 +189,16 @@ mod tests {
 
     #[test]
     fn test_mul_by_constant_modulo_power_two() {
-        for power in [127, 254] { //two randomish values
+        for power in [127, 254] {
+            //two randomish values
             let a = random_biguint_n_bits(254);
             let b = random_biguint_n_bits(254);
-            let circuit = U254::mul_by_constant_modulo_power_two(U254::wires_set_from_number(a.clone()), b.clone(), power);
-            let c = a * b % BigUint::from_str("2").unwrap().pow(power as u32); 
+            let circuit = U254::mul_by_constant_modulo_power_two(
+                U254::wires_set_from_number(a.clone()),
+                b.clone(),
+                power,
+            );
+            let c = a * b % BigUint::from_str("2").unwrap().pow(power as u32);
             circuit.gate_counts().print();
 
             for mut gate in circuit.1 {

--- a/src/circuits/bigint/mul.rs
+++ b/src/circuits/bigint/mul.rs
@@ -10,7 +10,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
         let mut circuit = Circuit::empty();
         for _ in 0..(N_BITS * 2) {
-            let wire = Rc::new(RefCell::new(Wire::new()));
+            let wire = new_wirex();
             wire.borrow_mut().set(false);
             circuit.add_wire(wire)
         } //this part can be optimized later 
@@ -39,7 +39,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         let mut circuit = Circuit::empty();
 
         for _ in 0..(N_BITS * 2) {
-            let wire = Rc::new(RefCell::new(Wire::new()));
+            let wire = new_wirex();
             wire.borrow_mut().set(false);
             circuit.add_wire(wire)
         } //this part can be optimized later 
@@ -85,8 +85,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 #[cfg(test)]
 mod tests {
     use crate::circuits::bigint::{
-        U254,
-        utils::{biguint_from_bits, random_u254, wires_set_from_u254},
+        utils::{biguint_from_bits, random_biguint_n_bits}, U254
     };
 
     //tests are currently only for 254 bits
@@ -94,11 +93,11 @@ mod tests {
     #[test]
     fn test_mul() {
         for _ in 0..10 {
-            let a = random_u254();
-            let b = random_u254();
+            let a = random_biguint_n_bits(254);
+            let b = random_biguint_n_bits(254);
             let circuit = U254::mul(
-                wires_set_from_u254(a.clone()),
-                wires_set_from_u254(b.clone()),
+                U254::wires_set_from_number(a.clone()),
+                U254::wires_set_from_number(b.clone()),
             );
             let c = a * b;
             circuit.gate_counts().print();
@@ -121,9 +120,9 @@ mod tests {
     #[test]
     fn test_mul_by_constant() {
         for _ in 0..10 {
-            let a = random_u254();
-            let b = random_u254();
-            let circuit = U254::mul_by_constant(wires_set_from_u254(a.clone()), b.clone());
+            let a = random_biguint_n_bits(254);
+            let b = random_biguint_n_bits(254);
+            let circuit = U254::mul_by_constant(U254::wires_set_from_number(a.clone()), b.clone());
             let c = a * b;
             circuit.gate_counts().print();
 

--- a/src/circuits/bigint/mul.rs
+++ b/src/circuits/bigint/mul.rs
@@ -28,13 +28,10 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         circuit
     }
 
-    ///Assuming constant is smaller than 2^N_BITS, and returns 2 * N_BITS result for now (can be optimized)
     pub fn mul_by_constant(a_wires: Vec<Rc<RefCell<Wire>>>, c: BigUint) -> Circuit {
         assert_eq!(a_wires.len(), N_BITS);
         let mut c_bits = bits_from_biguint(c);
         c_bits.truncate(N_BITS);
-        //assert!(c_bits.len() < N_BITS, "{} is too long", c_bits.len());
-        //this check doesn't work for now
 
         let mut circuit = Circuit::empty();
 
@@ -80,10 +77,51 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         */
         circuit
     }
+
+       pub fn mul_by_constant_modulo_power_two(a_wires: Vec<Rc<RefCell<Wire>>>, c: BigUint, power: usize) -> Circuit {
+        assert_eq!(a_wires.len(), N_BITS);
+        assert!(power < 2 * N_BITS);
+        let mut c_bits = bits_from_biguint(c);
+        c_bits.truncate(N_BITS);
+
+        let mut circuit = Circuit::empty();
+
+        for _ in 0..power {
+            let wire = new_wirex();
+            wire.borrow_mut().set(false);
+            circuit.add_wire(wire)
+        } //this part can be optimized later 
+
+        for (i, bit) in c_bits.iter().enumerate() {
+            if i == power {
+                break;
+            }
+            if *bit {
+                let mut addition_wires = vec![];
+                let number_of_bits = (power - i).min(N_BITS);
+                for j in i..(i + number_of_bits) {
+                    addition_wires.push(circuit.0[j].clone());
+                }
+                let new_bits = circuit.extend(Self::add_generic(a_wires[0..number_of_bits].to_vec(), addition_wires, number_of_bits));
+                if i + number_of_bits < power {
+                    circuit.0[i..(i + number_of_bits + 1)]
+                    .clone_from_slice(&new_bits);
+                } else {
+                     circuit.0[i..(i + number_of_bits)]
+                    .clone_from_slice(&new_bits[..number_of_bits]);
+                }
+            }
+        }
+        circuit
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use num_bigint::BigUint;
+
     use crate::circuits::bigint::{
         utils::{biguint_from_bits, random_biguint_n_bits}, U254
     };
@@ -124,6 +162,30 @@ mod tests {
             let b = random_biguint_n_bits(254);
             let circuit = U254::mul_by_constant(U254::wires_set_from_number(a.clone()), b.clone());
             let c = a * b;
+            circuit.gate_counts().print();
+
+            for mut gate in circuit.1 {
+                gate.evaluate();
+            }
+
+            let result = biguint_from_bits(
+                circuit
+                    .0
+                    .iter()
+                    .map(|output_wire| output_wire.borrow().get_value())
+                    .collect(),
+            );
+            assert_eq!(result, c);
+        }
+    }
+
+    #[test]
+    fn test_mul_by_constant_modulo_power_two() {
+        for power in [127, 254] { //two randomish values
+            let a = random_biguint_n_bits(254);
+            let b = random_biguint_n_bits(254);
+            let circuit = U254::mul_by_constant_modulo_power_two(U254::wires_set_from_number(a.clone()), b.clone(), power);
+            let c = a * b % BigUint::from_str("2").unwrap().pow(power as u32); 
             circuit.gate_counts().print();
 
             for mut gate in circuit.1 {

--- a/src/circuits/bigint/utils.rs
+++ b/src/circuits/bigint/utils.rs
@@ -4,8 +4,8 @@ use rand::{Rng, rng};
 use std::str::FromStr;
 // Constant byte array representing 2^254
 const TWO_POW_254_BYTES_LE: [u8; 32] = [
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x40,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0x40,
 ];
 
 #[inline(always)]

--- a/src/circuits/bigint/utils.rs
+++ b/src/circuits/bigint/utils.rs
@@ -1,16 +1,25 @@
-use super::U254;
 use crate::bag::*;
 use num_bigint::BigUint;
 use rand::{Rng, rng};
 use std::str::FromStr;
+// Constant byte array representing 2^254
+const TWO_POW_254_BYTES_LE: [u8; 32] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x40,
+];
+
+#[inline(always)]
+pub fn biguint_two_pow_254() -> BigUint {
+    BigUint::from_bytes_le(&TWO_POW_254_BYTES_LE)
+}
 
 pub fn random_biguint() -> BigUint {
     BigUint::from_bytes_le(&rng().random::<[u8; 32]>())
 }
 
-pub fn random_u254() -> BigUint {
+pub fn random_biguint_n_bits(n_bits: usize) -> BigUint {
     BigUint::from_bytes_le(&rand::rng().random::<[u8; 32]>())
-        % BigUint::from_str("2").unwrap().pow(254)
+        % BigUint::from_str("2").unwrap().pow(n_bits as u32)
 }
 
 pub fn bits_from_biguint(u: BigUint) -> Vec<bool> {
@@ -35,21 +44,8 @@ pub fn biguint_from_bits(bits: Vec<bool>) -> BigUint {
     u
 }
 
-pub fn wires_for_u254() -> Wires {
-    (0..U254::N_BITS)
-        .map(|_| Rc::new(RefCell::new(Wire::new())))
-        .collect()
-}
-
-pub fn wires_set_from_u254(u: BigUint) -> Wires {
-    bits_from_biguint(u)[0..U254::N_BITS]
-        .iter()
-        .map(|bit| {
-            let wire = Rc::new(RefCell::new(Wire::new()));
-            wire.borrow_mut().set(*bit);
-            wire
-        })
-        .collect()
+pub fn n_wires(n: usize) -> Wires {
+    (0..n).map(|_| new_wirex()).collect()
 }
 
 pub fn biguint_from_wires(wires: Wires) -> BigUint {

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -86,14 +86,14 @@ pub trait Fp254Impl {
         let c = Self::not_modulus_as_biguint();
         let mut wires_2 = circuit.extend(U254::add_constant(wires_1.clone(), c));
         wires_2.pop();
-        let not_u = Rc::new(RefCell::new(Wire::new()));
+        let not_u = new_wirex();
         circuit.add(Gate::not(u.clone(), not_u.clone()));
         let v = circuit.extend(U254::less_than_constant(
             wires_1.clone(),
             Self::modulus_as_biguint(),
         ))[0]
             .clone();
-        let s = Rc::new(RefCell::new(Wire::new()));
+        let s = new_wirex();
         circuit.add(Gate::and(not_u.clone(), v.clone(), s.clone()));
         let wires_3 = circuit.extend(U254::select(wires_1, wires_2, s));
         circuit.add_wires(wires_3);
@@ -114,14 +114,14 @@ pub trait Fp254Impl {
         let c = Self::not_modulus_as_biguint();
         let mut wires_2 = circuit.extend(U254::add_constant(wires_1.clone(), c));
         wires_2.pop();
-        let not_u = Rc::new(RefCell::new(Wire::new()));
+        let not_u = new_wirex();
         circuit.add(Gate::not(u.clone(), not_u.clone()));
         let v = circuit.extend(U254::less_than_constant(
             wires_1.clone(),
             Self::modulus_as_biguint(),
         ))[0]
             .clone();
-        let s = Rc::new(RefCell::new(Wire::new()));
+        let s = new_wirex();
         circuit.add(Gate::and(not_u.clone(), v.clone(), s.clone()));
         let wires_3 = circuit.extend(U254::select(wires_1, wires_2, s));
         circuit.add_wires(wires_3);
@@ -160,9 +160,9 @@ pub trait Fp254Impl {
         assert_eq!(a.len(), Self::N_BITS);
         let mut circuit = Circuit::empty();
 
-        let shift_wire = Rc::new(RefCell::new(Wire::new()));
+        let shift_wire = new_wirex();
         let x = a[0].clone();
-        let not_x = Rc::new(RefCell::new(Wire::new()));
+        let not_x = new_wirex();
         circuit.add(Gate::not(x.clone(), not_x.clone()));
         circuit.add(Gate::and(x.clone(), not_x.clone(), shift_wire.clone()));
         let mut aa = a.clone();
@@ -172,14 +172,14 @@ pub trait Fp254Impl {
         let c = Self::not_modulus_as_biguint();
         let mut wires_2 = circuit.extend(U254::add_constant(shifted_wires.clone(), c));
         wires_2.pop();
-        let not_u = Rc::new(RefCell::new(Wire::new()));
+        let not_u = new_wirex();
         circuit.add(Gate::not(u.clone(), not_u.clone()));
         let v = circuit.extend(U254::less_than_constant(
             shifted_wires.clone(),
             Self::modulus_as_biguint(),
         ))[0]
             .clone();
-        let s = Rc::new(RefCell::new(Wire::new()));
+        let s = new_wirex();
         circuit.add(Gate::and(not_u.clone(), v.clone(), s.clone()));
         let result = circuit.extend(U254::select(shifted_wires, wires_2, s));
         circuit.add_wires(result);
@@ -343,25 +343,25 @@ pub trait Fp254Impl {
         for _ in 0..2 * Self::N_BITS {
             let x1x = u[0].clone();
             let x2x = v[0].clone();
-            let x1 = Rc::new(RefCell::new(Wire::new()));
-            let x2 = Rc::new(RefCell::new(Wire::new()));
+            let x1 = new_wirex();
+            let x2 = new_wirex();
             circuit.add(Gate::not(x1x.clone(), x1.clone()));
             circuit.add(Gate::not(x2x.clone(), x2.clone()));
             let x3 = circuit.extend(U254::greater_than(u.clone(), v.clone()))[0].clone();
 
             let p1 = x1.clone();
-            let not_x1 = Rc::new(RefCell::new(Wire::new()));
+            let not_x1 = new_wirex();
             circuit.add(Gate::not(x1.clone(), not_x1.clone()));
-            let p2 = Rc::new(RefCell::new(Wire::new()));
+            let p2 = new_wirex();
             circuit.add(Gate::and(not_x1.clone(), x2.clone(), p2.clone()));
-            let p3 = Rc::new(RefCell::new(Wire::new()));
-            let not_x2 = Rc::new(RefCell::new(Wire::new()));
+            let p3 = new_wirex();
+            let not_x2 = new_wirex();
             circuit.add(Gate::not(x2, not_x2.clone()));
-            let wires_2 = Rc::new(RefCell::new(Wire::new()));
+            let wires_2 = new_wirex();
             circuit.add(Gate::and(not_x1.clone(), not_x2.clone(), wires_2.clone()));
             circuit.add(Gate::and(wires_2.clone(), x3.clone(), p3.clone()));
-            let p4 = Rc::new(RefCell::new(Wire::new()));
-            let not_x3 = Rc::new(RefCell::new(Wire::new()));
+            let p4 = new_wirex();
+            let not_x3 = new_wirex();
             circuit.add(Gate::not(x3.clone(), not_x3.clone()));
             circuit.add(Gate::and(wires_2, not_x3, p4.clone()));
 
@@ -513,8 +513,8 @@ pub trait Fp254Impl {
 
         let half = circuit.extend(Self::half(a.clone()));
         let mut result = Fq::wires();
-        let mut r1 = Rc::new(RefCell::new(Wire::new()));
-        let mut r2 = Rc::new(RefCell::new(Wire::new()));
+        let mut r1 = new_wirex();
+        let mut r2 = new_wirex();
         r1.borrow_mut().set(false);
         r2.borrow_mut().set(false);
         for i in 0..U254::N_BITS {
@@ -522,14 +522,14 @@ pub trait Fp254Impl {
             let j = U254::N_BITS - 1 - i;
 
             // result wire
-            let r2_and_hj = Rc::new(RefCell::new(Wire::new()));
+            let r2_and_hj = new_wirex();
             circuit.add(Gate::and(r2.clone(), half[j].clone(), r2_and_hj.clone()));
-            let result_wire = Rc::new(RefCell::new(Wire::new()));
+            let result_wire = new_wirex();
             circuit.add(Gate::or(r1.clone(), r2_and_hj.clone(), result_wire.clone()));
             result[j] = result_wire.clone();
             // update r1 r2 values
-            let not_hj = Rc::new(RefCell::new(Wire::new()));
-            let not_r2 = Rc::new(RefCell::new(Wire::new()));
+            let not_hj = new_wirex();
+            let not_r2 = new_wirex();
             circuit.add(Gate::not(half[j].clone(), not_hj.clone()));
             circuit.add(Gate::not(r2.clone(), not_r2.clone()));
             r1 = circuit.extend(selector(not_r2.clone(), r2.clone(), result_wire.clone()))[0]
@@ -542,9 +542,9 @@ pub trait Fp254Impl {
                 .clone();
 
             // special case if 1 0 0 then 0 1 instead of 1 1 so we need to not r1 if 1 0 0 is the case
-            let not_r1 = Rc::new(RefCell::new(Wire::new()));
+            let not_r1 = new_wirex();
             circuit.add(Gate::not(r1.clone(), not_r1.clone()));
-            let edge_case = Rc::new(RefCell::new(Wire::new()));
+            let edge_case = new_wirex();
             circuit.add(Gate::and(result_wire.clone(), not_hj, edge_case.clone()));
             r1 = circuit.extend(selector(not_r1.clone(), r1.clone(), edge_case))[0].clone();
         }

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -248,7 +248,7 @@ pub trait Fp254Impl {
         let result = circuit.extend(U254::optimized_sub(x_high, new_sub, false));
         circuit.add_wires(result);
 
-        return circuit;
+        circuit
     }
 
     fn mul_montgomery(a: Wires, b: Wires) -> Circuit {
@@ -256,7 +256,7 @@ pub trait Fp254Impl {
         let reduction_circuit = Self::montgomery_reduce(mul_circuit.0);
         let mut result_circuit = Circuit::new(reduction_circuit.0, mul_circuit.1);
         result_circuit.1.extend(reduction_circuit.1);
-        return result_circuit;
+        result_circuit
     }
 
     fn mul_by_constant(a: Wires, b: ark_bn254::Fq) -> Circuit {
@@ -311,7 +311,7 @@ pub trait Fp254Impl {
         let reduction_circuit = Self::montgomery_reduce(mul_circuit.0);
         let mut result_circuit = Circuit::new(reduction_circuit.0, mul_circuit.1);
         result_circuit.1.extend(reduction_circuit.1);
-        return result_circuit;
+        result_circuit
     }
 
     fn square(a: Wires) -> Circuit {

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -509,9 +509,10 @@ pub trait Fp254Impl {
         let mut circuit = Circuit::empty();
 
         let b = circuit.extend(Fq::inverse(a.clone()));
-        let result = circuit.extend(Fq::mul_by_constant(
+        let result = circuit.extend(Fq::mul_by_constant_montgomery(
             b,
-            ark_bn254::Fq::from(Fq::montgomery_r_as_biguint()).square(),
+            ark_bn254::Fq::from(Fq::montgomery_r_as_biguint()).square()
+                * ark_bn254::Fq::from(Fq::montgomery_r_as_biguint()),
         ));
 
         circuit.add_wires(result);

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use ark_ff::{AdditiveGroup, Field};
 use num_bigint::BigUint;
-use std::{str::FromStr};
+use std::str::FromStr;
 
 pub trait Fp254Impl {
     const MODULUS: &'static str;
@@ -235,7 +235,7 @@ pub trait Fp254Impl {
         let q = circuit.extend(U254::mul_by_constant_modulo_power_two(
             x_low,
             Self::montgomery_m_inverse_as_biguint(),
-            254
+            254,
         ));
         let sub =
             circuit.extend(U254::mul_by_constant(q, Self::modulus_as_biguint()))[254..508].to_vec();
@@ -248,7 +248,7 @@ pub trait Fp254Impl {
         let result = circuit.extend(U254::optimized_sub(x_high, new_sub, false));
         circuit.add_wires(result);
 
-        return circuit
+        return circuit;
     }
 
     fn mul_montgomery(a: Wires, b: Wires) -> Circuit {
@@ -256,7 +256,7 @@ pub trait Fp254Impl {
         let reduction_circuit = Self::montgomery_reduce(mul_circuit.0);
         let mut result_circuit = Circuit::new(reduction_circuit.0, mul_circuit.1);
         result_circuit.1.extend(reduction_circuit.1);
-        return result_circuit
+        return result_circuit;
     }
 
     fn mul_by_constant(a: Wires, b: ark_bn254::Fq) -> Circuit {
@@ -311,7 +311,7 @@ pub trait Fp254Impl {
         let reduction_circuit = Self::montgomery_reduce(mul_circuit.0);
         let mut result_circuit = Circuit::new(reduction_circuit.0, mul_circuit.1);
         result_circuit.1.extend(reduction_circuit.1);
-        return result_circuit
+        return result_circuit;
     }
 
     fn square(a: Wires) -> Circuit {

--- a/src/circuits/bn254/fq.rs
+++ b/src/circuits/bn254/fq.rs
@@ -68,16 +68,14 @@ impl Fq {
     }
 
     pub fn wires() -> Wires {
-        (0..Self::N_BITS)
-            .map(|_| Rc::new(RefCell::new(Wire::new())))
-            .collect()
+        (0..Self::N_BITS).map(|_| new_wirex()).collect()
     }
 
     pub fn wires_set(u: ark_bn254::Fq) -> Wires {
         Self::to_bits(u)[0..Self::N_BITS]
             .iter()
             .map(|bit| {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 wire.borrow_mut().set(*bit);
                 wire
             })

--- a/src/circuits/bn254/fq12.rs
+++ b/src/circuits/bn254/fq12.rs
@@ -40,16 +40,14 @@ impl Fq12 {
     }
 
     pub fn wires() -> Wires {
-        (0..Self::N_BITS)
-            .map(|_| Rc::new(RefCell::new(Wire::new())))
-            .collect()
+        (0..Self::N_BITS).map(|_| new_wirex()).collect()
     }
 
     pub fn wires_set(u: ark_bn254::Fq12) -> Wires {
         Self::to_bits(u)[0..Self::N_BITS]
             .iter()
             .map(|bit| {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 wire.borrow_mut().set(*bit);
                 wire
             })
@@ -98,7 +96,7 @@ impl Fq12 {
         let mut wire = results[0].clone();
 
         for next in results[1..].iter().cloned() {
-            let new_wire = Rc::new(RefCell::new(Wire::new()));
+            let new_wire = new_wirex();
             circuit.add(Gate::and(wire, next, new_wire.clone()));
             wire = new_wire;
         }

--- a/src/circuits/bn254/fq2.rs
+++ b/src/circuits/bn254/fq2.rs
@@ -39,16 +39,14 @@ impl Fq2 {
     }
 
     pub fn wires() -> Wires {
-        (0..Self::N_BITS)
-            .map(|_| Rc::new(RefCell::new(Wire::new())))
-            .collect()
+        (0..Self::N_BITS).map(|_| new_wirex()).collect()
     }
 
     pub fn wires_set(u: ark_bn254::Fq2) -> Wires {
         Self::to_bits(u)[0..Self::N_BITS]
             .iter()
             .map(|bit| {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 wire.borrow_mut().set(*bit);
                 wire
             })

--- a/src/circuits/bn254/fq6.rs
+++ b/src/circuits/bn254/fq6.rs
@@ -50,16 +50,14 @@ impl Fq6 {
     }
 
     pub fn wires() -> Wires {
-        (0..Self::N_BITS)
-            .map(|_| Rc::new(RefCell::new(Wire::new())))
-            .collect()
+        (0..Self::N_BITS).map(|_| new_wirex()).collect()
     }
 
     pub fn wires_set(u: ark_bn254::Fq6) -> Wires {
         Self::to_bits(u)[0..Self::N_BITS]
             .iter()
             .map(|bit| {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 wire.borrow_mut().set(*bit);
                 wire
             })

--- a/src/circuits/bn254/fr.rs
+++ b/src/circuits/bn254/fr.rs
@@ -67,16 +67,14 @@ impl Fr {
     }
 
     pub fn wires() -> Wires {
-        (0..Self::N_BITS)
-            .map(|_| Rc::new(RefCell::new(Wire::new())))
-            .collect()
+        (0..Self::N_BITS).map(|_| new_wirex()).collect()
     }
 
     pub fn wires_set(u: ark_bn254::Fr) -> Wires {
         Self::to_bits(u)[0..Self::N_BITS]
             .iter()
             .map(|bit| {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 wire.borrow_mut().set(*bit);
                 wire
             })

--- a/src/circuits/bn254/g1.rs
+++ b/src/circuits/bn254/g1.rs
@@ -68,16 +68,14 @@ impl G1Projective {
     }
 
     pub fn wires() -> Wires {
-        (0..Self::N_BITS)
-            .map(|_| Rc::new(RefCell::new(Wire::new())))
-            .collect()
+        (0..Self::N_BITS).map(|_| new_wirex()).collect()
     }
 
     pub fn wires_set(u: ark_bn254::G1Projective) -> Wires {
         Self::to_bits(u)[0..Self::N_BITS]
             .iter()
             .map(|bit| {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 wire.borrow_mut().set(*bit);
                 wire
             })
@@ -739,7 +737,7 @@ mod tests {
         let w = 10;
         let n = 2_usize.pow(w as u32);
         let a: Vec<ark_bn254::G1Projective> = (0..n).map(|_| G1Projective::random()).collect();
-        let s: Wires = (0..w).map(|_| Rc::new(RefCell::new(Wire::new()))).collect();
+        let s: Wires = (0..w).map(|_| new_wirex()).collect();
 
         let mut a_wires = Vec::new();
         for e in a.clone() {
@@ -771,7 +769,7 @@ mod tests {
         let w = 10;
         let n = 2_usize.pow(w as u32);
         let a: Vec<ark_bn254::G1Projective> = (0..n).map(|_| G1Projective::random()).collect();
-        let s: Wires = (0..w).map(|_| Rc::new(RefCell::new(Wire::new()))).collect();
+        let s: Wires = (0..w).map(|_| new_wirex()).collect();
 
         let mut a_wires = Vec::new();
         for e in a.clone() {

--- a/src/circuits/bn254/g2.rs
+++ b/src/circuits/bn254/g2.rs
@@ -61,16 +61,14 @@ impl G2Projective {
     }
 
     pub fn wires() -> Wires {
-        (0..Self::N_BITS)
-            .map(|_| Rc::new(RefCell::new(Wire::new())))
-            .collect()
+        (0..Self::N_BITS).map(|_| new_wirex()).collect()
     }
 
     pub fn wires_set(u: ark_bn254::G2Projective) -> Wires {
         Self::to_bits(u)[0..Self::N_BITS]
             .iter()
             .map(|bit| {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 wire.borrow_mut().set(*bit);
                 wire
             })
@@ -147,7 +145,7 @@ impl G2Affine {
         Self::to_bits(u)[0..Self::N_BITS]
             .iter()
             .map(|bit| {
-                let wire = Rc::new(RefCell::new(Wire::new()));
+                let wire = new_wirex();
                 wire.borrow_mut().set(*bit);
                 wire
             })

--- a/src/core/bristol.rs
+++ b/src/core/bristol.rs
@@ -10,7 +10,7 @@ pub fn parser(filename: &str) -> (Circuit, Vec<Wires>, Vec<Wires>) {
     let now: usize = words.next().unwrap().parse().unwrap();
     let mut wires = Vec::new();
     for _ in 0..now {
-        wires.push(Rc::new(RefCell::new(Wire::new())));
+        wires.push(new_wirex());
     }
 
     let mut input_sizes = Vec::<usize>::new();

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -552,9 +552,9 @@ mod tests {
 
     #[test]
     fn test_gate() {
-        let wire_1 = Rc::new(RefCell::new(Wire::new()));
-        let wire_2 = Rc::new(RefCell::new(Wire::new()));
-        let wire_3 = Rc::new(RefCell::new(Wire::new()));
+        let wire_1 = new_wirex();
+        let wire_2 = new_wirex();
+        let wire_3 = new_wirex();
         let gate = Gate::and(wire_1, wire_2, wire_3);
 
         let correct_garbled = gate.garbled();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,7 @@ pub mod bag {
     pub type Wirex = Rc<RefCell<Wire>>;
     pub type Wires = Vec<Wirex>;
     pub use crate::core::gate::GateCount;
+    pub fn new_wirex() -> Wirex {
+        Rc::new(RefCell::new(Wire::new()))
+    }
 }


### PR DESCRIPTION
This PR optimizes gate count of `Fq::mul_montgomery` by ~10% and `Fq::mul_by_constant_montgomery` by ~45%. 
Also, some functions in bigint weren't compatible with bit sizes other than 254, which was caused due to the usage of wrong methods in wire creation, this PR adds a minor refactor that fixes those bugs and makes constructing wires cleaner. 

It requires chainwayxyz/main to be merged first to be compatible. 