### PR TITLE
feat: constant optimizer

### DIFF
--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -155,10 +155,8 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
     pub fn double(a: Wires) -> Circuit {
         assert_eq!(a.len(), N_BITS);
         let mut circuit = Circuit::empty();
-        let not_a = Rc::new(RefCell::new(Wire::new()));
         let zero_wire = Rc::new(RefCell::new(Wire::new()));
-        circuit.add(Gate::not(a[0].clone(), not_a.clone()));
-        circuit.add(Gate::and(a[0].clone(), not_a.clone(), zero_wire.clone()));
+        circuit.add_const(false, a[0].clone(), zero_wire.clone());
         circuit.add_wire(zero_wire);
         circuit.add_wires(a[0..N_BITS - 1].to_vec());
         circuit
@@ -167,10 +165,8 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
     pub fn half(a: Wires) -> Circuit {
         assert_eq!(a.len(), N_BITS);
         let mut circuit = Circuit::empty();
-        let not_a = Rc::new(RefCell::new(Wire::new()));
         let zero_wire = Rc::new(RefCell::new(Wire::new()));
-        circuit.add(Gate::not(a[0].clone(), not_a.clone()));
-        circuit.add(Gate::and(a[0].clone(), not_a.clone(), zero_wire.clone()));
+        circuit.add_const(false, a[0].clone(), zero_wire.clone());
         circuit.add_wires(a[1..N_BITS].to_vec());
         circuit.add_wire(zero_wire);
         circuit
@@ -378,7 +374,10 @@ mod tests {
             gate.evaluate();
         }
         let c = biguint_from_wires(circuit.0);
-        assert_eq!(c, a.clone() + a.clone());
+        assert_eq!(
+            c,
+            (a.clone() + a.clone()) % BigUint::from_str("2").unwrap().pow(254)
+        );
     }
 
     #[test]

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -161,10 +161,7 @@ pub trait Fp254Impl {
         let mut circuit = Circuit::empty();
 
         let shift_wire = Rc::new(RefCell::new(Wire::new()));
-        let x = a[0].clone();
-        let not_x = Rc::new(RefCell::new(Wire::new()));
-        circuit.add(Gate::not(x.clone(), not_x.clone()));
-        circuit.add(Gate::and(x.clone(), not_x.clone(), shift_wire.clone()));
+        circuit.add_const(false, a[0].clone(), shift_wire.clone());
         let mut aa = a.clone();
         let u = aa.pop().unwrap();
         let mut shifted_wires = vec![shift_wire];

--- a/src/circuits/bn254/fq.rs
+++ b/src/circuits/bn254/fq.rs
@@ -166,7 +166,8 @@ mod tests {
     #[test]
     fn test_fq_double() {
         let a = Fq::random();
-        let circuit = Fq::double(Fq::wires_set(a));
+        let mut circuit = Fq::double(Fq::wires_set(a));
+        circuit.optimize_consts();
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -178,7 +179,9 @@ mod tests {
     #[test]
     fn test_fq_half() {
         let a = Fq::random();
-        let circuit = Fq::half(Fq::wires_set(a));
+        let mut circuit = Fq::half(Fq::wires_set(a));
+       
+        circuit.optimize_consts();
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -203,7 +206,8 @@ mod tests {
     fn test_fq_mul() {
         let a = Fq::random();
         let b = Fq::random();
-        let circuit = Fq::mul(Fq::wires_set(a), Fq::wires_set(b));
+        let mut circuit = Fq::mul(Fq::wires_set(a), Fq::wires_set(b));
+        circuit.optimize_consts();
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();

--- a/src/circuits/bn254/fq12.rs
+++ b/src/circuits/bn254/fq12.rs
@@ -711,7 +711,8 @@ mod tests {
     #[test]
     fn test_fq12_double() {
         let a = Fq12::random();
-        let circuit = Fq12::double(Fq12::wires_set(a));
+        let mut circuit = Fq12::double(Fq12::wires_set(a));
+        circuit.optimize_consts();
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();

--- a/src/circuits/bn254/fq2.rs
+++ b/src/circuits/bn254/fq2.rs
@@ -547,7 +547,8 @@ mod tests {
     #[test]
     fn test_fq2_double() {
         let a = Fq2::random();
-        let circuit = Fq2::double(Fq2::wires_set(a));
+        let mut circuit = Fq2::double(Fq2::wires_set(a));
+        circuit.optimize_consts();
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();

--- a/src/circuits/bn254/fq6.rs
+++ b/src/circuits/bn254/fq6.rs
@@ -1085,7 +1085,8 @@ mod tests {
     #[test]
     fn test_fq6_double() {
         let a = Fq6::random();
-        let circuit = Fq6::double(Fq6::wires_set(a));
+        let mut circuit = Fq6::double(Fq6::wires_set(a));
+        circuit.optimize_consts();
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();

--- a/src/core/s.rs
+++ b/src/core/s.rs
@@ -2,7 +2,7 @@ use blake3::hash;
 use rand::{Rng, rng};
 use std::{iter::zip, ops::Add};
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash, Eq)]
 pub struct S(pub [u8; 32]);
 
 impl S {

--- a/src/core/wire.rs
+++ b/src/core/wire.rs
@@ -2,7 +2,7 @@ use crate::core::s::S;
 use crate::core::utils::{LIMB_LEN, N_LIMBS, convert_between_blake3_and_normal_form};
 use bitvm::{bigint::U256, hash::blake3::blake3_compute_script_with_limb, treepp::*};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Wire {
     pub label0: S,
     pub label1: S,


### PR DESCRIPTION
Implements an optimization as a post-processing step that propagates constants, removing unused gates in the process. For example, `[a OR true]` gets substituted by `true`, while `[a AND true]` gets substituted by just the wire `a`.

This reduces the number of gates in the full-adder from 5 to 2 when one of the inputs is a constant `false` value. This is the optimal number of gates, so that's nice. However, when one of the inputs is a constant `true`, it only gets reduced to 4 gates (2 is optimal). To match the hand-written implementation of the `add_constant` function, you would need multi-gate analysis (i.e. an analysis that sees `[OR(a, AND(b, NOT(a)))]` and optimizes it to `[OR(a, b)]`.

Anyway, the optimization results are.. not super impressive. This is partly because as far as I can tell, there aren't many constants in the circuit - I've only found them in halving and doubling functions. The most significant change I've seen is a 0.65% reduction in the number of gates in `fq12_double`

Given these numbers I'm not sure it's worth it to actually run this, but leaving this pr here anyway