### PR TITLE
optimize Fq2 and Fq12 square, switch to better Fq6 square

### DIFF
--- a/src/circuits/bn254/fq12.rs
+++ b/src/circuits/bn254/fq12.rs
@@ -467,36 +467,42 @@ impl Fq12 {
     pub fn square(a: Wires) -> Circuit {
         assert_eq!(a.len(), Self::N_BITS);
         let mut circuit = Circuit::empty();
+
         let a_c0 = a[0..Fq6::N_BITS].to_vec();
         let a_c1 = a[Fq6::N_BITS..2 * Fq6::N_BITS].to_vec();
-        let wires_1 = circuit.extend(Fq6::add(a_c0.clone(), a_c1.clone()));
-        let wires_2 = circuit.extend(Fq6::square(a_c0.clone()));
-        let wires_3 = circuit.extend(Fq6::square(a_c1.clone()));
-        let wires_4 = circuit.extend(Fq6::add(wires_2.clone(), wires_3.clone()));
-        let wires_5 = circuit.extend(Fq6::mul_by_nonresidue(wires_3.clone()));
-        let wires_6 = circuit.extend(Fq6::add(wires_5.clone(), wires_2.clone()));
-        let wires_7 = circuit.extend(Fq6::mul(wires_1.clone(), wires_1.clone()));
-        let wires_8 = circuit.extend(Fq6::sub(wires_7.clone(), wires_4.clone()));
-        circuit.add_wires(wires_6);
-        circuit.add_wires(wires_8);
+
+        let v0 = circuit.extend(Fq6::add(a_c0.clone(), a_c1.clone()));
+        let a_c1_beta = circuit.extend(Fq6::mul_by_nonresidue(a_c1.clone()));
+        let v3 = circuit.extend(Fq6::add(a_c0.clone(), a_c1_beta.clone()));
+        let v2 = circuit.extend(Fq6::mul(a_c0.clone(), a_c1.clone()));
+        let v0 = circuit.extend(Fq6::mul(v0, v3));
+        let v2_beta = circuit.extend(Fq6::mul_by_nonresidue(v2.clone()));
+        let v2_beta_plus_v2 = circuit.extend(Fq6::add(v2_beta, v2.clone()));
+        let c0 = circuit.extend(Fq6::sub(v0, v2_beta_plus_v2));
+        let c1 = circuit.extend(Fq6::double(v2));
+        circuit.add_wires(c0);
+        circuit.add_wires(c1);
         circuit
     }
 
     pub fn square_montgomery(a: Wires) -> Circuit {
         assert_eq!(a.len(), Self::N_BITS);
         let mut circuit = Circuit::empty();
+
         let a_c0 = a[0..Fq6::N_BITS].to_vec();
         let a_c1 = a[Fq6::N_BITS..2 * Fq6::N_BITS].to_vec();
-        let wires_1 = circuit.extend(Fq6::add(a_c0.clone(), a_c1.clone()));
-        let wires_2 = circuit.extend(Fq6::square_montgomery(a_c0.clone()));
-        let wires_3 = circuit.extend(Fq6::square_montgomery(a_c1.clone()));
-        let wires_4 = circuit.extend(Fq6::add(wires_2.clone(), wires_3.clone()));
-        let wires_5 = circuit.extend(Fq6::mul_by_nonresidue(wires_3.clone()));
-        let wires_6 = circuit.extend(Fq6::add(wires_5.clone(), wires_2.clone()));
-        let wires_7 = circuit.extend(Fq6::mul_montgomery(wires_1.clone(), wires_1.clone()));
-        let wires_8 = circuit.extend(Fq6::sub(wires_7.clone(), wires_4.clone()));
-        circuit.add_wires(wires_6);
-        circuit.add_wires(wires_8);
+
+        let v0 = circuit.extend(Fq6::add(a_c0.clone(), a_c1.clone()));
+        let a_c1_beta = circuit.extend(Fq6::mul_by_nonresidue(a_c1.clone()));
+        let v3 = circuit.extend(Fq6::add(a_c0.clone(), a_c1_beta.clone()));
+        let v2 = circuit.extend(Fq6::mul_montgomery(a_c0.clone(), a_c1.clone()));
+        let v0 = circuit.extend(Fq6::mul_montgomery(v0, v3));
+        let v2_beta = circuit.extend(Fq6::mul_by_nonresidue(v2.clone()));
+        let v2_beta_plus_v2 = circuit.extend(Fq6::add(v2_beta, v2.clone()));
+        let c0 = circuit.extend(Fq6::sub(v0, v2_beta_plus_v2));
+        let c1 = circuit.extend(Fq6::double(v2));
+        circuit.add_wires(c0);
+        circuit.add_wires(c1);
         circuit
     }
 

--- a/src/circuits/bn254/fq2.rs
+++ b/src/circuits/bn254/fq2.rs
@@ -365,15 +365,14 @@ impl Fq2 {
         let a_c0 = a[0..Fq::N_BITS].to_vec();
         let a_c1 = a[Fq::N_BITS..2 * Fq::N_BITS].to_vec();
 
-        let wires_1 = circuit.extend(Fq::add(a_c0.clone(), a_c1.clone()));
-        let wires_2 = circuit.extend(Fq::square(a_c0.clone()));
-        let wires_3 = circuit.extend(Fq::square(a_c1.clone()));
-        let wires_4 = circuit.extend(Fq::add(wires_2.clone(), wires_3.clone()));
-        let wires_5 = circuit.extend(Fq::sub(wires_2.clone(), wires_3.clone()));
-        let wires_6 = circuit.extend(Fq::square(wires_1.clone()));
-        let wires_7 = circuit.extend(Fq::sub(wires_6.clone(), wires_4.clone()));
-        circuit.add_wires(wires_5);
-        circuit.add_wires(wires_7);
+        let a_c0_plus_a_c1 = circuit.extend(Fq::add(a_c0.clone(), a_c1.clone()));
+        let a_c0_minus_a_c1 = circuit.extend(Fq::sub(a_c0.clone(), a_c1.clone()));
+        let a_c0_a_c1 = circuit.extend(Fq::mul(a_c0.clone(), a_c1));
+        let a_c0_square_minus_a_c1_square =
+            circuit.extend(Fq::mul(a_c0_plus_a_c1.clone(), a_c0_minus_a_c1));
+        let a_c0_a_c1_double = circuit.extend(Fq::double(a_c0_a_c1));
+        circuit.add_wires(a_c0_square_minus_a_c1_square);
+        circuit.add_wires(a_c0_a_c1_double);
         circuit
     }
 
@@ -384,15 +383,14 @@ impl Fq2 {
         let a_c0 = a[0..Fq::N_BITS].to_vec();
         let a_c1 = a[Fq::N_BITS..2 * Fq::N_BITS].to_vec();
 
-        let wires_1 = circuit.extend(Fq::add(a_c0.clone(), a_c1.clone()));
-        let wires_2 = circuit.extend(Fq::square_montgomery(a_c0.clone()));
-        let wires_3 = circuit.extend(Fq::square_montgomery(a_c1.clone()));
-        let wires_4 = circuit.extend(Fq::add(wires_2.clone(), wires_3.clone()));
-        let wires_5 = circuit.extend(Fq::sub(wires_2.clone(), wires_3.clone()));
-        let wires_6 = circuit.extend(Fq::square_montgomery(wires_1.clone()));
-        let wires_7 = circuit.extend(Fq::sub(wires_6.clone(), wires_4.clone()));
-        circuit.add_wires(wires_5);
-        circuit.add_wires(wires_7);
+        let a_c0_plus_a_c1 = circuit.extend(Fq::add(a_c0.clone(), a_c1.clone()));
+        let a_c0_minus_a_c1 = circuit.extend(Fq::sub(a_c0.clone(), a_c1.clone()));
+        let a_c0_a_c1 = circuit.extend(Fq::mul_montgomery(a_c0.clone(), a_c1));
+        let a_c0_square_minus_a_c1_square =
+            circuit.extend(Fq::mul_montgomery(a_c0_plus_a_c1.clone(), a_c0_minus_a_c1));
+        let a_c0_a_c1_double = circuit.extend(Fq::double(a_c0_a_c1));
+        circuit.add_wires(a_c0_square_minus_a_c1_square);
+        circuit.add_wires(a_c0_a_c1_double);
         circuit
     }
 

--- a/src/circuits/bn254/fq6.rs
+++ b/src/circuits/bn254/fq6.rs
@@ -726,80 +726,8 @@ impl Fq6 {
         circuit
     }
 
-    pub fn square(a: Wires) -> Circuit {
-        assert_eq!(a.len(), Self::N_BITS);
-        let mut circuit = Circuit::empty();
-
-        let a_c0 = a[0..Fq2::N_BITS].to_vec();
-        let a_c1 = a[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
-        let a_c2 = a[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec();
-
-        let v0 = circuit.extend(Fq2::square(a_c0.clone()));
-        let wires_1: Vec<Rc<RefCell<Wire>>> = circuit.extend(Fq2::mul(a_c0.clone(), a_c1.clone()));
-        let v1: Vec<Rc<RefCell<Wire>>> = circuit.extend(Fq2::double(wires_1));
-        let wires_2: Vec<Rc<RefCell<Wire>>> = circuit.extend(Fq2::add(a_c0.clone(), a_c2.clone()));
-        let wires_3: Vec<Rc<RefCell<Wire>>> =
-            circuit.extend(Fq2::sub(wires_2.clone(), a_c1.clone()));
-        let v2 = circuit.extend(Fq2::square(wires_3));
-        let wires_4: Vec<Rc<RefCell<Wire>>> = circuit.extend(Fq2::mul(a_c2.clone(), a_c1.clone()));
-        let v3: Vec<Rc<RefCell<Wire>>> = circuit.extend(Fq2::double(wires_4));
-        let v4 = circuit.extend(Fq2::square(a_c2.clone()));
-
-        let v3_b = circuit.extend(Fq2::mul_by_nonresidue(v3.clone()));
-        let v4_b = circuit.extend(Fq2::mul_by_nonresidue(v4.clone()));
-
-        let c0 = circuit.extend(Fq2::add(v0.clone(), v3_b.clone()));
-        let c1 = circuit.extend(Fq2::add(v1.clone(), v4_b.clone()));
-        let wires_5 = circuit.extend(Fq2::add(v1.clone(), v2));
-        let wires_6 = circuit.extend(Fq2::add(wires_5, v3));
-        let wires_7 = circuit.extend(Fq2::add(v4, v0.clone()));
-        let c2 = circuit.extend(Fq2::sub(wires_6, wires_7));
-
-        circuit.add_wires(c0);
-        circuit.add_wires(c1);
-        circuit.add_wires(c2);
-        circuit
-    }
-
-    pub fn square_montgomery(a: Wires) -> Circuit {
-        assert_eq!(a.len(), Self::N_BITS);
-        let mut circuit = Circuit::empty();
-
-        let a_c0 = a[0..Fq2::N_BITS].to_vec();
-        let a_c1 = a[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
-        let a_c2 = a[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec();
-
-        let v0 = circuit.extend(Fq2::square_montgomery(a_c0.clone()));
-        let wires_1: Vec<Rc<RefCell<Wire>>> =
-            circuit.extend(Fq2::mul_montgomery(a_c0.clone(), a_c1.clone()));
-        let v1: Vec<Rc<RefCell<Wire>>> = circuit.extend(Fq2::double(wires_1));
-        let wires_2: Vec<Rc<RefCell<Wire>>> = circuit.extend(Fq2::add(a_c0.clone(), a_c2.clone()));
-        let wires_3: Vec<Rc<RefCell<Wire>>> =
-            circuit.extend(Fq2::sub(wires_2.clone(), a_c1.clone()));
-        let v2 = circuit.extend(Fq2::square_montgomery(wires_3));
-        let wires_4: Vec<Rc<RefCell<Wire>>> =
-            circuit.extend(Fq2::mul_montgomery(a_c2.clone(), a_c1.clone()));
-        let v3: Vec<Rc<RefCell<Wire>>> = circuit.extend(Fq2::double(wires_4));
-        let v4 = circuit.extend(Fq2::square_montgomery(a_c2.clone()));
-
-        let v3_b = circuit.extend(Fq2::mul_by_nonresidue(v3.clone()));
-        let v4_b = circuit.extend(Fq2::mul_by_nonresidue(v4.clone()));
-
-        let c0 = circuit.extend(Fq2::add(v0.clone(), v3_b.clone()));
-        let c1 = circuit.extend(Fq2::add(v1.clone(), v4_b.clone()));
-        let wires_5 = circuit.extend(Fq2::add(v1.clone(), v2));
-        let wires_6 = circuit.extend(Fq2::add(wires_5, v3));
-        let wires_7 = circuit.extend(Fq2::add(v4, v0.clone()));
-        let c2 = circuit.extend(Fq2::sub(wires_6, wires_7));
-
-        circuit.add_wires(c0);
-        circuit.add_wires(c1);
-        circuit.add_wires(c2);
-        circuit
-    }
-
     // https://eprint.iacr.org/2006/471.pdf
-    pub fn square_v2(a: Wires) -> Circuit {
+    pub fn square(a: Wires) -> Circuit {
         assert_eq!(a.len(), Self::N_BITS);
         let mut circuit = Circuit::empty();
 
@@ -834,7 +762,7 @@ impl Fq6 {
         circuit
     }
 
-    pub fn square_v2_montgomery(a: Wires) -> Circuit {
+    pub fn square_montgomery(a: Wires) -> Circuit {
         assert_eq!(a.len(), Self::N_BITS);
         let mut circuit = Circuit::empty();
 
@@ -1302,32 +1230,6 @@ mod tests {
     fn test_fq6_square_montgomery() {
         let a = Fq6::random();
         let circuit = Fq6::square_montgomery(Fq6::wires_set_montgomery(a));
-        circuit.gate_counts().print();
-        for mut gate in circuit.1 {
-            gate.evaluate();
-        }
-        let c = Fq6::from_wires(circuit.0);
-        assert_eq!(c, Fq6::as_montgomery(a * a));
-    }
-
-    #[test]
-    #[serial]
-    fn test_fq6_square_v2() {
-        let a = Fq6::random();
-        let circuit = Fq6::square_v2(Fq6::wires_set(a));
-        circuit.gate_counts().print();
-        for mut gate in circuit.1 {
-            gate.evaluate();
-        }
-        let c = Fq6::from_wires(circuit.0);
-        assert_eq!(c, a * a);
-    }
-
-    #[test]
-    #[serial]
-    fn test_fq6_square_v2_montgomery() {
-        let a = Fq6::random();
-        let circuit = Fq6::square_v2_montgomery(Fq6::wires_set_montgomery(a));
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -365,12 +365,12 @@ impl GateCount {
 
     pub fn fq12_square() -> Self {
         Self {
-            and: 14689194,
-            or: 8799016,
-            xor: 11748341,
-            nand: 17650968,
-            not: 11861704,
-            xnor: 5861174,
+            and: 12112256,
+            or: 7260636,
+            xor: 9693597,
+            nand: 14567916,
+            not: 9792178,
+            xnor: 4837396,
             nimp: 0,
             nsor: 0,
         }
@@ -378,13 +378,13 @@ impl GateCount {
 
     pub fn fq12_square_montgomery() -> Self {
         Self {
-            and: 13055919,
-            or: 5119231,
-            xor: 10160651,
-            nand: 300228,
-            not: 226279,
-            xnor: 100364,
-            nimp: 22860,
+            and: 8786734,
+            or: 3473842,
+            xor: 6852296,
+            nand: 344424,
+            not: 247730,
+            xnor: 108020,
+            nimp: 15240,
             nsor: 0,
         }
     }
@@ -469,12 +469,12 @@ impl GateCount {
 
     pub fn double_in_place() -> Self {
         Self {
-            and: 9224370,
-            or: 5611730,
-            xor: 7459948,
-            nand: 11352276,
-            not: 7627100,
-            xnor: 3771914,
+            and: 7285002,
+            or: 4452836,
+            xor: 5912236,
+            nand: 9029700,
+            not: 6066530,
+            xnor: 3000110,
             nimp: 0,
             nsor: 0,
         }
@@ -482,25 +482,25 @@ impl GateCount {
 
     pub fn double_in_place_montgomery() -> Self {
         Self {
-            and: 8224699,
-            or: 3252150,
-            xor: 6490272,
-            nand: 81534,
-            not: 68935,
-            xnor: 29791,
-            nimp: 15240,
+            and: 6503101,
+            or: 2583894,
+            xor: 5154252,
+            nand: 72390,
+            not: 59755,
+            xnor: 26095,
+            nimp: 12192,
             nsor: 0,
         }
     }
 
     pub fn add_in_place() -> Self {
         Self {
-            and: 12615983,
-            or: 7543041,
-            xor: 10070137,
-            nand: 15127986,
-            not: 10164952,
-            xnor: 5027209,
+            and: 11969527,
+            or: 7156743,
+            xor: 9554233,
+            nand: 14353794,
+            not: 9644762,
+            xnor: 4769941,
             nimp: 0,
             nsor: 0,
         }
@@ -508,13 +508,13 @@ impl GateCount {
 
     pub fn add_in_place_montgomery() -> Self {
         Self {
-            and: 11200478,
-            or: 4353894,
-            xor: 8694139,
-            nand: 90678,
-            not: 80917,
-            xnor: 34507,
-            nimp: 19812,
+            and: 10626612,
+            or: 4131142,
+            xor: 8248799,
+            nand: 87630,
+            not: 77857,
+            xnor: 33275,
+            nimp: 18796,
             nsor: 0,
         }
     }


### PR DESCRIPTION
This PR optimizes Fq2::square and Fq12::square to use 2 muls instead of 3. There was a Fq6::square_v2 which is better if Fq2::mul is better than Fq2::square. And now we can switch to that too. 0.6B improvement to Groth16 Verifier Circuit. Closes #9 