### PR TITLE
Add fan out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ ark-crypto-primitives = "0.5.0"
 ark-relations = "0.5.0"
 serial_test = "3.2.0"
 once_cell = "1.21.3"
+
+[profile.dev]
+opt-level = 3

--- a/src/circuits/basic.rs
+++ b/src/circuits/basic.rs
@@ -127,11 +127,11 @@ mod tests {
 
             let circuit = half_adder(a_wire, b_wire);
 
-            for mut gate in circuit.1 {
+            for mut gate in circuit.gates() {
                 gate.evaluate();
             }
 
-            let (c_wire, d_wire) = (circuit.0[0].clone(), circuit.0[1].clone());
+            let (c_wire, d_wire) = (circuit.wires[0].clone(), circuit.wires[1].clone());
 
             assert_eq!(c_wire.borrow().get_value(), c);
             assert_eq!(d_wire.borrow().get_value(), d);
@@ -163,11 +163,11 @@ mod tests {
 
             let circuit = full_adder(a_wire, b_wire, c_wire);
 
-            for mut gate in circuit.1 {
+            for mut gate in circuit.gates() {
                 gate.evaluate();
             }
 
-            let (d_wire, e_wire) = (circuit.0[0].clone(), circuit.0[1].clone());
+            let (d_wire, e_wire) = (circuit.wires[0].clone(), circuit.wires[1].clone());
 
             assert_eq!(d_wire.borrow().get_value(), d);
             assert_eq!(e_wire.borrow().get_value(), e);
@@ -192,11 +192,11 @@ mod tests {
 
             let circuit = half_subtracter(a_wire, b_wire);
 
-            for mut gate in circuit.1 {
+            for mut gate in circuit.gates() {
                 gate.evaluate();
             }
 
-            let (c_wire, d_wire) = (circuit.0[0].clone(), circuit.0[1].clone());
+            let (c_wire, d_wire) = (circuit.wires[0].clone(), circuit.wires[1].clone());
 
             assert_eq!(c_wire.borrow().get_value(), c);
             assert_eq!(d_wire.borrow().get_value(), d);
@@ -228,11 +228,11 @@ mod tests {
 
             let circuit = full_subtracter(a_wire, b_wire, c_wire);
 
-            for mut gate in circuit.1 {
+            for mut gate in circuit.gates() {
                 gate.evaluate();
             }
 
-            let (d_wire, e_wire) = (circuit.0[0].clone(), circuit.0[1].clone());
+            let (d_wire, e_wire) = (circuit.wires[0].clone(), circuit.wires[1].clone());
 
             assert_eq!(d_wire.borrow().get_value(), d);
             assert_eq!(e_wire.borrow().get_value(), e);
@@ -264,11 +264,11 @@ mod tests {
 
             let circuit = selector(a_wire, b_wire, c_wire);
 
-            for mut gate in circuit.1 {
+            for mut gate in circuit.gates() {
                 gate.evaluate();
             }
 
-            let d_wire = circuit.0[0].clone();
+            let d_wire = circuit.wires[0].clone();
 
             assert_eq!(d_wire.borrow().get_value(), d);
         }
@@ -295,11 +295,11 @@ mod tests {
         let circuit = multiplexer(a.clone(), s.clone(), w);
         circuit.gate_counts().print();
 
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
 
-        let result = circuit.0[0].clone().borrow().get_value();
+        let result = circuit.wires[0].clone().borrow().get_value();
         let expected = a[u].clone().borrow().get_value();
 
         assert_eq!(result, expected);

--- a/src/circuits/basic.rs
+++ b/src/circuits/basic.rs
@@ -293,7 +293,7 @@ mod tests {
         }
 
         let circuit = multiplexer(a.clone(), s.clone(), w);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
 
         for mut gate in circuit.gates() {
             gate.evaluate();

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -449,12 +449,12 @@ mod tests {
         for _ in 0..10 {
             let a = random_biguint_n_bits(254);
             let b = random_biguint_n_bits(254);
-            let circuit = U254::optimized_sub(
+            let mut circuit = U254::optimized_sub(
                 U254::wires_set_from_number(a.clone()),
                 U254::wires_set_from_number(b.clone()),
                 true,
             );
-            circuit.gate_counts().print();
+            circuit.circuit_metricss().print();
             let bound_check = circuit.wires.pop().unwrap();
             let output_wires = circuit.wires.clone();
             for mut gate in circuit.gates() {

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -48,7 +48,7 @@ pub fn optimized_sub_generic(
             circuit.add(Gate::xor(
                 subtract_bit.clone(),
                 a_wires[i].clone(),
-                circuit.0[i].clone(),
+                circuit.wires[i].clone(),
             ));
             let new_want_or0 = new_wirex();
             let new_want_or1 = new_wirex();
@@ -73,7 +73,7 @@ pub fn optimized_sub_generic(
             circuit.add(Gate::xor(
                 b_wires[i].clone(),
                 a_wires[i].clone(),
-                circuit.0[i].clone(),
+                circuit.wires[i].clone(),
             ));
             let new_want: Rc<RefCell<Wire>> = new_wirex();
             circuit.add(Gate::nimp(
@@ -320,10 +320,10 @@ mod tests {
             U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(c, a + b);
     }
 
@@ -333,10 +333,10 @@ mod tests {
         let b = random_biguint_n_bits(254);
         let circuit = U254::add_constant(U254::wires_set_from_number(a.clone()), b.clone());
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(c, a + b);
     }
 
@@ -349,10 +349,10 @@ mod tests {
             U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(c, (a + b) % biguint_two_pow_254());
     }
 
@@ -368,10 +368,10 @@ mod tests {
             U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(c, a - b);
     }
 
@@ -387,10 +387,10 @@ mod tests {
             U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(c, (a - b) % biguint_two_pow_254());
     }
 
@@ -399,10 +399,10 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let circuit = U254::double(U254::wires_set_from_number(a.clone()));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(c, a.clone() + a);
     }
 
@@ -411,10 +411,10 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let circuit = U254::double_without_overflow(U254::wires_set_from_number(a.clone()));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(c, (a.clone() + a) % biguint_two_pow_254());
     }
 
@@ -423,10 +423,10 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let circuit = U254::half(U254::wires_set_from_number(a.clone()));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         let d = a.clone() - c.clone() - c.clone();
         assert!(d == BigUint::ZERO || d == BigUint::from_str("1").unwrap());
     }
@@ -436,11 +436,11 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let circuit = U254::odd_part(U254::wires_set_from_number(a.clone()));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0[0..U254::N_BITS].to_vec());
-        let d = biguint_from_wires(circuit.0[U254::N_BITS..2 * U254::N_BITS].to_vec());
+        let c = biguint_from_wires(circuit.wires[0..U254::N_BITS].to_vec());
+        let d = biguint_from_wires(circuit.wires[U254::N_BITS..2 * U254::N_BITS].to_vec());
         assert_eq!(a, c * d);
     }
 
@@ -455,9 +455,9 @@ mod tests {
                 true,
             );
             circuit.gate_counts().print();
-            let bound_check = circuit.0.pop().unwrap();
-            let output_wires = circuit.0;
-            for mut gate in circuit.1 {
+            let bound_check = circuit.wires.pop().unwrap();
+            let output_wires = circuit.wires.clone();
+            for mut gate in circuit.gates() {
                 gate.evaluate();
             }
             if a < b {

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -319,7 +319,7 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
             U254::wires_set_from_number(b.clone()),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -332,7 +332,7 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
         let circuit = U254::add_constant(U254::wires_set_from_number(a.clone()), b.clone());
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -348,7 +348,7 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
             U254::wires_set_from_number(b.clone()),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -367,7 +367,7 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
             U254::wires_set_from_number(b.clone()),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -386,7 +386,7 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
             U254::wires_set_from_number(b.clone()),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -398,7 +398,7 @@ mod tests {
     fn test_double() {
         let a = random_biguint_n_bits(254);
         let circuit = U254::double(U254::wires_set_from_number(a.clone()));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -410,7 +410,7 @@ mod tests {
     fn test_double_without_overflow() {
         let a = random_biguint_n_bits(254);
         let circuit = U254::double_without_overflow(U254::wires_set_from_number(a.clone()));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -422,7 +422,7 @@ mod tests {
     fn test_half() {
         let a = random_biguint_n_bits(254);
         let circuit = U254::half(U254::wires_set_from_number(a.clone()));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -435,7 +435,7 @@ mod tests {
     fn test_odd_part() {
         let a = random_biguint_n_bits(254);
         let circuit = U254::odd_part(U254::wires_set_from_number(a.clone()));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -449,7 +449,7 @@ mod tests {
         for _ in 0..10 {
             let a = random_biguint_n_bits(254);
             let b = random_biguint_n_bits(254);
-            let mut circuit = U254::optimized_sub(
+            let circuit = U254::optimized_sub(
                 U254::wires_set_from_number(a.clone()),
                 U254::wires_set_from_number(b.clone()),
                 true,

--- a/src/circuits/bigint/cmp.rs
+++ b/src/circuits/bigint/cmp.rs
@@ -160,10 +160,10 @@ mod tests {
             U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        assert_eq!(a == b, circuit.0[0].borrow().get_value());
+        assert_eq!(a == b, circuit.wires[0].borrow().get_value());
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::equal(
@@ -171,18 +171,18 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        assert!(circuit.0[0].borrow().get_value());
+        assert!(circuit.wires[0].borrow().get_value());
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::equal_constant(U254::wires_set_from_number(a.clone()), b.clone());
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        assert_eq!(a == b, circuit.0[0].borrow().get_value());
+        assert_eq!(a == b, circuit.wires[0].borrow().get_value());
     }
 
     #[test]
@@ -194,10 +194,10 @@ mod tests {
             U254::wires_set_from_number(b.clone()),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        assert_eq!(a > b, circuit.0[0].borrow().get_value());
+        assert_eq!(a > b, circuit.wires[0].borrow().get_value());
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
@@ -205,10 +205,10 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        assert!(!circuit.0[0].borrow().get_value());
+        assert!(!circuit.wires[0].borrow().get_value());
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
@@ -216,10 +216,10 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        assert!(circuit.0[0].borrow().get_value());
+        assert!(circuit.wires[0].borrow().get_value());
     }
 
     #[test]
@@ -228,10 +228,10 @@ mod tests {
         let b = random_biguint_n_bits(254);
         let circuit = U254::less_than_constant(U254::wires_set_from_number(a.clone()), b.clone());
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        assert_eq!(a < b, circuit.0[0].borrow().get_value());
+        assert_eq!(a < b, circuit.wires[0].borrow().get_value());
     }
 
     #[test]
@@ -246,10 +246,10 @@ mod tests {
             s,
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(a, c);
     }
 
@@ -261,19 +261,19 @@ mod tests {
         s.borrow_mut().set(true);
         let circuit = U254::self_or_zero(U254::wires_set_from_number(a.clone()), s);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(a, c);
 
         let s = new_wirex();
         s.borrow_mut().set(false);
         let circuit = U254::self_or_zero(U254::wires_set_from_number(a.clone()), s);
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = biguint_from_wires(circuit.0);
+        let c = biguint_from_wires(circuit.wires);
         assert_eq!(c, BigUint::ZERO);
     }
 
@@ -299,11 +299,11 @@ mod tests {
         let circuit = U254::multiplexer(a_wires, s.clone(), w);
         circuit.gate_counts().print();
 
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
 
-        let result = biguint_from_wires(circuit.0);
+        let result = biguint_from_wires(circuit.wires);
         let expected = a[u].clone();
 
         assert_eq!(result, expected);

--- a/src/circuits/bigint/cmp.rs
+++ b/src/circuits/bigint/cmp.rs
@@ -159,7 +159,7 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
             U254::wires_set_from_number(b.clone()),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -170,7 +170,7 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
             U254::wires_set_from_number(a.clone()),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -178,7 +178,7 @@ mod tests {
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::equal_constant(U254::wires_set_from_number(a.clone()), b.clone());
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -193,7 +193,7 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
             U254::wires_set_from_number(b.clone()),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -204,7 +204,7 @@ mod tests {
             U254::wires_set_from_number(a.clone()),
             U254::wires_set_from_number(a.clone()),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -215,7 +215,7 @@ mod tests {
             U254::wires_set_from_number(a.clone() + BigUint::from_str("1").unwrap()),
             U254::wires_set_from_number(a.clone()),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -227,7 +227,7 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
         let circuit = U254::less_than_constant(U254::wires_set_from_number(a.clone()), b.clone());
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -245,7 +245,7 @@ mod tests {
             U254::wires_set_from_number(b.clone()),
             s,
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -260,7 +260,7 @@ mod tests {
         let s = new_wirex();
         s.borrow_mut().set(true);
         let circuit = U254::self_or_zero(U254::wires_set_from_number(a.clone()), s);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -297,7 +297,7 @@ mod tests {
         }
 
         let circuit = U254::multiplexer(a_wires, s.clone(), w);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
 
         for mut gate in circuit.gates() {
             gate.evaluate();

--- a/src/circuits/bigint/mul.rs
+++ b/src/circuits/bigint/mul.rs
@@ -269,7 +269,7 @@ mod tests {
                 U254::wires_set_from_number(b.clone()),
             );
             let c = a * b;
-            circuit.gate_counts().print();
+            circuit.circuit_metricss().print();
 
             for mut gate in circuit.gates() {
                 gate.evaluate();
@@ -350,7 +350,7 @@ mod tests {
             let b = random_biguint_n_bits(254);
             let circuit = U254::mul_by_constant(U254::wires_set_from_number(a.clone()), b.clone());
             let c = a * b;
-            circuit.gate_counts().print();
+            circuit.circuit_metricss().print();
 
             for mut gate in circuit.gates() {
                 gate.evaluate();
@@ -379,7 +379,7 @@ mod tests {
                 power,
             );
             let c = a * b % BigUint::from_str("2").unwrap().pow(power as u32);
-            circuit.gate_counts().print();
+            circuit.circuit_metricss().print();
 
             for mut gate in circuit.gates() {
                 gate.evaluate();

--- a/src/circuits/bigint/mul.rs
+++ b/src/circuits/bigint/mul.rs
@@ -133,7 +133,9 @@ pub fn mul_karatsuba_generic(a_wires: &Wires, b_wires: &Wires, len: usize) -> Ci
             circuit.wires[(2 * len_0)..].clone_from_slice(&new_segment[..(2 * len_1)]);
         }
 
-        if circuit.gate_count() < min_circuit.gate_count() || min_circuit.gate_count() == 0 {
+        if circuit.circuit_metrics() < min_circuit.circuit_metrics()
+            || min_circuit.circuit_metrics() == 0
+        {
             set_karatsuba_decision_flag(len, true);
             min_circuit = circuit;
         }
@@ -296,7 +298,7 @@ mod tests {
                 U254::wires_set_from_number(b.clone()),
             );
             let c = a * b;
-            circuit.gate_counts().print();
+            circuit.circuit_metricss().print();
 
             for mut gate in circuit.gates() {
                 gate.evaluate();
@@ -326,7 +328,7 @@ mod tests {
                 T::wires_set_from_number(b.clone()),
             );
             let c = a * b;
-            circuit.gate_counts().print();
+            circuit.circuit_metricss().print();
 
             for mut gate in circuit.gates() {
                 gate.evaluate();

--- a/src/circuits/bn254/finalexp.rs
+++ b/src/circuits/bn254/finalexp.rs
@@ -25,9 +25,9 @@ pub fn cyclotomic_exp(f: ark_bn254::Fq12) -> ark_bn254::Fq12 {
     res
 }
 
-pub fn cyclotomic_exp_evaluate_fast(f: Wires) -> (Wires, GateCount) {
+pub fn cyclotomic_exp_evaluate_fast(f: Wires) -> (Wires, CircuitMetrics) {
     let mut res = Fq12::wires_set(ark_bn254::Fq12::ONE);
-    let mut gate_count = GateCount::zero();
+    let mut circuit_metrics = CircuitMetrics::zero();
     let mut found_nonzero = false;
     for value in BitIteratorBE::without_leading_zeros(ark_bn254::Config::X)
         .map(|e| e as i8)
@@ -36,10 +36,10 @@ pub fn cyclotomic_exp_evaluate_fast(f: Wires) -> (Wires, GateCount) {
         if found_nonzero {
             let (wires1, gc) = (
                 Fq12::wires_set(Fq12::from_wires(res.clone()).square()),
-                GateCount::fq12_cyclotomic_square(),
+                CircuitMetrics::fq12_cyclotomic_square(),
             ); //Fq12::square_evaluate(res.clone());
             res = wires1;
-            gate_count += gc;
+            circuit_metrics += gc;
         }
 
         if value != 0 {
@@ -48,19 +48,19 @@ pub fn cyclotomic_exp_evaluate_fast(f: Wires) -> (Wires, GateCount) {
             if value > 0 {
                 let (wires2, gc) = (
                     Fq12::wires_set(Fq12::from_wires(res.clone()) * Fq12::from_wires(f.clone())),
-                    GateCount::fq12_mul(),
+                    CircuitMetrics::fq12_mul(),
                 ); // Fq12::mul_evaluate(res.clone(), f.clone());
                 res = wires2;
-                gate_count += gc;
+                circuit_metrics += gc;
             }
         }
     }
-    (res, gate_count)
+    (res, circuit_metrics)
 }
 
-pub fn cyclotomic_exp_evaluate_montgomery_fast(f: Wires) -> (Wires, GateCount) {
+pub fn cyclotomic_exp_evaluate_montgomery_fast(f: Wires) -> (Wires, CircuitMetrics) {
     let mut res = Fq12::wires_set_montgomery(ark_bn254::Fq12::ONE);
-    let mut gate_count = GateCount::zero();
+    let mut circuit_metrics = CircuitMetrics::zero();
     let mut found_nonzero = false;
     for value in BitIteratorBE::without_leading_zeros(ark_bn254::Config::X)
         .map(|e| e as i8)
@@ -69,10 +69,10 @@ pub fn cyclotomic_exp_evaluate_montgomery_fast(f: Wires) -> (Wires, GateCount) {
         if found_nonzero {
             let (wires1, gc) = (
                 Fq12::wires_set_montgomery(Fq12::from_montgomery_wires(res.clone()).square()),
-                GateCount::fq12_cyclotomic_square_montgomery(),
+                CircuitMetrics::fq12_cyclotomic_square_montgomery(),
             ); //Fq12::square_evaluate_montgomery(res.clone());
             res = wires1;
-            gate_count += gc;
+            circuit_metrics += gc;
         }
 
         if value != 0 {
@@ -84,14 +84,14 @@ pub fn cyclotomic_exp_evaluate_montgomery_fast(f: Wires) -> (Wires, GateCount) {
                         Fq12::from_montgomery_wires(res.clone())
                             * Fq12::from_montgomery_wires(f.clone()),
                     ),
-                    GateCount::fq12_mul_montgomery(),
+                    CircuitMetrics::fq12_mul_montgomery(),
                 ); // Fq12::mul_evaluate(res.clone(), f.clone());
                 res = wires2;
-                gate_count += gc;
+                circuit_metrics += gc;
             }
         }
     }
-    (res, gate_count)
+    (res, circuit_metrics)
 }
 
 pub fn cyclotomic_exp_fastinv(f: ark_bn254::Fq12) -> ark_bn254::Fq12 {
@@ -119,14 +119,14 @@ pub fn cyclotomic_exp_fastinv(f: ark_bn254::Fq12) -> ark_bn254::Fq12 {
     res
 }
 
-pub fn cyclotomic_exp_fast_inverse_evaluate_fast(f: Wires) -> (Wires, GateCount) {
+pub fn cyclotomic_exp_fast_inverse_evaluate_fast(f: Wires) -> (Wires, CircuitMetrics) {
     let mut res = Fq12::wires_set(ark_bn254::Fq12::ONE);
-    let mut gate_count = GateCount::zero();
+    let mut circuit_metrics = CircuitMetrics::zero();
     let (f_inverse, gc) = (
         Fq12::wires_set(Fq12::from_wires(f.clone()).inverse().unwrap()),
-        GateCount::fq12_inverse(),
+        CircuitMetrics::fq12_inverse(),
     ); //Fq12::inverse(res.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let mut found_nonzero = false;
     for value in ark_ff::biginteger::arithmetic::find_naf(ark_bn254::Config::X)
         .into_iter()
@@ -135,10 +135,10 @@ pub fn cyclotomic_exp_fast_inverse_evaluate_fast(f: Wires) -> (Wires, GateCount)
         if found_nonzero {
             let (wires1, gc) = (
                 Fq12::wires_set(Fq12::from_wires(res.clone()).square()),
-                GateCount::fq12_cyclotomic_square(),
+                CircuitMetrics::fq12_cyclotomic_square(),
             ); //Fq12::square_evaluate(res.clone());
             res = wires1;
-            gate_count += gc;
+            circuit_metrics += gc;
         }
 
         if value != 0 {
@@ -147,33 +147,33 @@ pub fn cyclotomic_exp_fast_inverse_evaluate_fast(f: Wires) -> (Wires, GateCount)
             if value > 0 {
                 let (wires2, gc) = (
                     Fq12::wires_set(Fq12::from_wires(res.clone()) * Fq12::from_wires(f.clone())),
-                    GateCount::fq12_mul(),
+                    CircuitMetrics::fq12_mul(),
                 ); // Fq12::mul_evaluate(res.clone(), f.clone());
                 res = wires2;
-                gate_count += gc;
+                circuit_metrics += gc;
             } else {
                 let (wires2, gc) = (
                     Fq12::wires_set(
                         Fq12::from_wires(res.clone()) * Fq12::from_wires(f_inverse.clone()),
                     ),
-                    GateCount::fq12_mul(),
+                    CircuitMetrics::fq12_mul(),
                 ); // Fq12::mul_evaluate(res.clone(), f_inverse.clone());
                 res = wires2;
-                gate_count += gc;
+                circuit_metrics += gc;
             }
         }
     }
-    (res, gate_count)
+    (res, circuit_metrics)
 }
 
-pub fn cyclotomic_exp_fast_inverse_evaluate_montgomery_fast(f: Wires) -> (Wires, GateCount) {
+pub fn cyclotomic_exp_fast_inverse_evaluate_montgomery_fast(f: Wires) -> (Wires, CircuitMetrics) {
     let mut res = Fq12::wires_set_montgomery(ark_bn254::Fq12::ONE);
-    let mut gate_count = GateCount::zero();
+    let mut circuit_metrics = CircuitMetrics::zero();
     let (f_inverse, gc) = (
         Fq12::wires_set_montgomery(Fq12::from_montgomery_wires(f.clone()).inverse().unwrap()),
-        GateCount::fq12_inverse_montgomery(),
+        CircuitMetrics::fq12_inverse_montgomery(),
     ); //Fq12::inverse(res.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let mut found_nonzero = false;
     for value in ark_ff::biginteger::arithmetic::find_naf(ark_bn254::Config::X)
         .into_iter()
@@ -182,10 +182,10 @@ pub fn cyclotomic_exp_fast_inverse_evaluate_montgomery_fast(f: Wires) -> (Wires,
         if found_nonzero {
             let (wires1, gc) = (
                 Fq12::wires_set_montgomery(Fq12::from_montgomery_wires(res.clone()).square()),
-                GateCount::fq12_cyclotomic_square_montgomery(),
+                CircuitMetrics::fq12_cyclotomic_square_montgomery(),
             ); //Fq12::square_evaluate_montgomery(res.clone());
             res = wires1;
-            gate_count += gc;
+            circuit_metrics += gc;
         }
 
         if value != 0 {
@@ -197,46 +197,46 @@ pub fn cyclotomic_exp_fast_inverse_evaluate_montgomery_fast(f: Wires) -> (Wires,
                         Fq12::from_montgomery_wires(res.clone())
                             * Fq12::from_montgomery_wires(f.clone()),
                     ),
-                    GateCount::fq12_mul_montgomery(),
+                    CircuitMetrics::fq12_mul_montgomery(),
                 ); // Fq12::mul_evaluate_montgomery(res.clone(), f.clone());
                 res = wires2;
-                gate_count += gc;
+                circuit_metrics += gc;
             } else {
                 let (wires2, gc) = (
                     Fq12::wires_set_montgomery(
                         Fq12::from_montgomery_wires(res.clone())
                             * Fq12::from_montgomery_wires(f_inverse.clone()),
                     ),
-                    GateCount::fq12_mul_montgomery(),
+                    CircuitMetrics::fq12_mul_montgomery(),
                 ); // Fq12::mul_evaluate_montgomery(res.clone(), f_inverse.clone());
                 res = wires2;
-                gate_count += gc;
+                circuit_metrics += gc;
             }
         }
     }
-    (res, gate_count)
+    (res, circuit_metrics)
 }
 
 pub fn exp_by_neg_x(f: ark_bn254::Fq12) -> ark_bn254::Fq12 {
     conjugate(cyclotomic_exp(f))
 }
 
-pub fn exp_by_neg_x_evaluate(f: Wires) -> (Wires, GateCount) {
-    let mut gate_count = GateCount::zero();
+pub fn exp_by_neg_x_evaluate(f: Wires) -> (Wires, CircuitMetrics) {
+    let mut circuit_metrics = CircuitMetrics::zero();
     let (f2, gc) = cyclotomic_exp_fast_inverse_evaluate_fast(f);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (f3, gc) = Fq12::conjugate_evaluate(f2);
-    gate_count += gc;
-    (f3, gate_count)
+    circuit_metrics += gc;
+    (f3, circuit_metrics)
 }
 
-pub fn exp_by_neg_x_evaluate_montgomery(f: Wires) -> (Wires, GateCount) {
-    let mut gate_count = GateCount::zero();
+pub fn exp_by_neg_x_evaluate_montgomery(f: Wires) -> (Wires, CircuitMetrics) {
+    let mut circuit_metrics = CircuitMetrics::zero();
     let (f2, gc) = cyclotomic_exp_fast_inverse_evaluate_montgomery_fast(f);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (f3, gc) = Fq12::conjugate_evaluate(f2);
-    gate_count += gc;
-    (f3, gate_count)
+    circuit_metrics += gc;
+    (f3, circuit_metrics)
 }
 
 pub fn final_exponentiation(f: ark_bn254::Fq12) -> ark_bn254::Fq12 {
@@ -267,242 +267,242 @@ pub fn final_exponentiation(f: ark_bn254::Fq12) -> ark_bn254::Fq12 {
     y19 * y17
 }
 
-pub fn final_exponentiation_evaluate_fast(f: Wires) -> (Wires, GateCount) {
-    let mut gate_count = GateCount::zero();
+pub fn final_exponentiation_evaluate_fast(f: Wires) -> (Wires, CircuitMetrics) {
+    let mut circuit_metrics = CircuitMetrics::zero();
     let (f_inv, gc) = (
         Fq12::wires_set(Fq12::from_wires(f.clone()).inverse().unwrap()),
-        GateCount::fq12_inverse(),
+        CircuitMetrics::fq12_inverse(),
     );
-    gate_count += gc;
+    circuit_metrics += gc;
     let (f_conjugate, gc) = Fq12::conjugate_evaluate(f.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (u, gc) = (
         Fq12::wires_set(Fq12::from_wires(f_inv) * Fq12::from_wires(f_conjugate)),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(f_inv, f_conjugate);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (u_frobenius, gc) = Fq12::frobenius_evaluate(u.clone(), 2);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (r, gc) = (
         Fq12::wires_set(Fq12::from_wires(u_frobenius) * Fq12::from_wires(u.clone())),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(u_frobenius, u.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y0, gc) = exp_by_neg_x_evaluate(r.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y1, gc) = (
         Fq12::wires_set(Fq12::from_wires(y0).square()),
-        GateCount::fq12_square(),
+        CircuitMetrics::fq12_square(),
     ); // Fq12::square_evaluate(y0);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y2, gc) = (
         Fq12::wires_set(Fq12::from_wires(y1.clone()).square()),
-        GateCount::fq12_square(),
+        CircuitMetrics::fq12_square(),
     ); // Fq12::square_evaluate(y1.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y3, gc) = (
         Fq12::wires_set(Fq12::from_wires(y1.clone()) * Fq12::from_wires(y2)),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(y1.clone(), y2);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y4, gc) = exp_by_neg_x_evaluate(y3.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y5, gc) = (
         Fq12::wires_set(Fq12::from_wires(y4.clone()).square()),
-        GateCount::fq12_square(),
+        CircuitMetrics::fq12_square(),
     ); // Fq12::square_evaluate(y4.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y6, gc) = exp_by_neg_x_evaluate(y5);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y7, gc) = Fq12::conjugate_evaluate(y3);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y8, gc) = Fq12::conjugate_evaluate(y6);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y9, gc) = (
         Fq12::wires_set(Fq12::from_wires(y8) * Fq12::from_wires(y4.clone())),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(y8, y4.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y10, gc) = (
         Fq12::wires_set(Fq12::from_wires(y9) * Fq12::from_wires(y7)),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(y9, y7);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y11, gc) = (
         Fq12::wires_set(Fq12::from_wires(y10.clone()) * Fq12::from_wires(y1)),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(y10.clone(), y1);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y12, gc) = (
         Fq12::wires_set(Fq12::from_wires(y10.clone()) * Fq12::from_wires(y4)),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(y10.clone(), y4);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y13, gc) = (
         Fq12::wires_set(Fq12::from_wires(y12) * Fq12::from_wires(r.clone())),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(y12, r.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y14, gc) = Fq12::frobenius_evaluate(y11.clone(), 1);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y15, gc) = (
         Fq12::wires_set(Fq12::from_wires(y14) * Fq12::from_wires(y13)),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(y14, y13);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y16, gc) = Fq12::frobenius_evaluate(y10, 2);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y17, gc) = (
         Fq12::wires_set(Fq12::from_wires(y16) * Fq12::from_wires(y15)),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(y16, y15);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (r2, gc) = Fq12::conjugate_evaluate(r);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y18, gc) = (
         Fq12::wires_set(Fq12::from_wires(r2) * Fq12::from_wires(y11)),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(r2, y11);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y19, gc) = Fq12::frobenius_evaluate(y18, 3);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y20, gc) = (
         Fq12::wires_set(Fq12::from_wires(y19) * Fq12::from_wires(y17)),
-        GateCount::fq12_mul(),
+        CircuitMetrics::fq12_mul(),
     ); // Fq12::mul_evaluate(y19, y17);
-    gate_count += gc;
-    (y20, gate_count)
+    circuit_metrics += gc;
+    (y20, circuit_metrics)
 }
 
-pub fn final_exponentiation_evaluate_montgomery_fast(f: Wires) -> (Wires, GateCount) {
-    let mut gate_count = GateCount::zero();
+pub fn final_exponentiation_evaluate_montgomery_fast(f: Wires) -> (Wires, CircuitMetrics) {
+    let mut circuit_metrics = CircuitMetrics::zero();
     let (f_inv, gc) = (
         Fq12::wires_set_montgomery(Fq12::from_montgomery_wires(f.clone()).inverse().unwrap()),
-        GateCount::fq12_inverse_montgomery(),
+        CircuitMetrics::fq12_inverse_montgomery(),
     );
-    gate_count += gc;
+    circuit_metrics += gc;
     let (f_conjugate, gc) = Fq12::conjugate_evaluate(f.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (u, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(f_inv) * Fq12::from_montgomery_wires(f_conjugate),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(f_inv, f_conjugate);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (u_frobenius, gc) = Fq12::frobenius_evaluate_montgomery(u.clone(), 2);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (r, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(u_frobenius) * Fq12::from_montgomery_wires(u.clone()),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(u_frobenius, u.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y0, gc) = exp_by_neg_x_evaluate_montgomery(r.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y1, gc) = (
         Fq12::wires_set_montgomery(Fq12::from_montgomery_wires(y0).square()),
-        GateCount::fq12_square_montgomery(),
+        CircuitMetrics::fq12_square_montgomery(),
     ); // Fq12::square_evaluate_montgomery(y0);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y2, gc) = (
         Fq12::wires_set_montgomery(Fq12::from_montgomery_wires(y1.clone()).square()),
-        GateCount::fq12_square_montgomery(),
+        CircuitMetrics::fq12_square_montgomery(),
     ); // Fq12::square_evaluate_montgomery(y1.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y3, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(y1.clone()) * Fq12::from_montgomery_wires(y2),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(y1.clone(), y2);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y4, gc) = exp_by_neg_x_evaluate_montgomery(y3.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y5, gc) = (
         Fq12::wires_set_montgomery(Fq12::from_montgomery_wires(y4.clone()).square()),
-        GateCount::fq12_square_montgomery(),
+        CircuitMetrics::fq12_square_montgomery(),
     ); // Fq12::square_evaluate_montgomery(y4.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y6, gc) = exp_by_neg_x_evaluate_montgomery(y5);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y7, gc) = Fq12::conjugate_evaluate(y3);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y8, gc) = Fq12::conjugate_evaluate(y6);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y9, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(y8) * Fq12::from_montgomery_wires(y4.clone()),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(y8, y4.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y10, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(y9) * Fq12::from_montgomery_wires(y7),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(y9, y7);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y11, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(y10.clone()) * Fq12::from_montgomery_wires(y1),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(y10.clone(), y1);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y12, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(y10.clone()) * Fq12::from_montgomery_wires(y4),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(y10.clone(), y4);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y13, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(y12) * Fq12::from_montgomery_wires(r.clone()),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(y12, r.clone());
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y14, gc) = Fq12::frobenius_evaluate_montgomery(y11.clone(), 1);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y15, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(y14) * Fq12::from_montgomery_wires(y13),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(y14, y13);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y16, gc) = Fq12::frobenius_evaluate_montgomery(y10, 2);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y17, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(y16) * Fq12::from_montgomery_wires(y15),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(y16, y15);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (r2, gc) = Fq12::conjugate_evaluate(r);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y18, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(r2) * Fq12::from_montgomery_wires(y11),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(r2, y11);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y19, gc) = Fq12::frobenius_evaluate_montgomery(y18, 3);
-    gate_count += gc;
+    circuit_metrics += gc;
     let (y20, gc) = (
         Fq12::wires_set_montgomery(
             Fq12::from_montgomery_wires(y19) * Fq12::from_montgomery_wires(y17),
         ),
-        GateCount::fq12_mul_montgomery(),
+        CircuitMetrics::fq12_mul_montgomery(),
     ); // Fq12::mul_evaluate_montgomery(y19, y17);
-    gate_count += gc;
-    (y20, gate_count)
+    circuit_metrics += gc;
+    (y20, circuit_metrics)
 }
 
 #[cfg(test)]
@@ -555,8 +555,8 @@ mod tests {
         let f = ark_bn254::Fq12::rand(&mut prng);
         let cyclotomic_f = f.pow(u.to_u64_digits());
         let c = cyclotomic_f.cyclotomic_exp(ark_bn254::Config::X);
-        let (d, gate_count) = cyclotomic_exp_evaluate_fast(Fq12::wires_set(cyclotomic_f));
-        gate_count.print();
+        let (d, circuit_metrics) = cyclotomic_exp_evaluate_fast(Fq12::wires_set(cyclotomic_f));
+        circuit_metrics.print();
         assert_eq!(c, Fq12::from_wires(d));
     }
 
@@ -566,9 +566,9 @@ mod tests {
         let f = ark_bn254::Fq12::rand(&mut prng);
 
         let c = cyclotomic_exp(f); // f.cyclotomic_exp(ark_bn254::Config::X);
-        let (d, gate_count) =
+        let (d, circuit_metrics) =
             cyclotomic_exp_evaluate_montgomery_fast(Fq12::wires_set_montgomery(f));
-        gate_count.print();
+        circuit_metrics.print();
         assert_eq!(c, Fq12::from_montgomery_wires(d));
     }
 
@@ -581,9 +581,9 @@ mod tests {
         let f = ark_bn254::Fq12::rand(&mut prng);
         let cyclotomic_f = f.pow(u.to_u64_digits());
         let c = cyclotomic_f.cyclotomic_exp(ark_bn254::Config::X);
-        let (d, gate_count) =
+        let (d, circuit_metrics) =
             cyclotomic_exp_fast_inverse_evaluate_fast(Fq12::wires_set(cyclotomic_f));
-        gate_count.print();
+        circuit_metrics.print();
         assert_eq!(c, Fq12::from_wires(d));
     }
 
@@ -596,10 +596,10 @@ mod tests {
         let f = ark_bn254::Fq12::rand(&mut prng);
         let cyclotomic_f = f.pow(u.to_u64_digits());
         let c = cyclotomic_f.cyclotomic_exp(ark_bn254::Config::X);
-        let (d, gate_count) = cyclotomic_exp_fast_inverse_evaluate_montgomery_fast(
+        let (d, circuit_metrics) = cyclotomic_exp_fast_inverse_evaluate_montgomery_fast(
             Fq12::wires_set_montgomery(cyclotomic_f),
         );
-        gate_count.print();
+        circuit_metrics.print();
         assert_eq!(c, Fq12::from_montgomery_wires(d));
     }
 
@@ -623,8 +623,8 @@ mod tests {
         let c = ark_bn254::Bn254::final_exponentiation(MillerLoopOutput(f))
             .unwrap()
             .0;
-        let (d, gate_count) = final_exponentiation_evaluate_fast(Fq12::wires_set(f));
-        gate_count.print();
+        let (d, circuit_metrics) = final_exponentiation_evaluate_fast(Fq12::wires_set(f));
+        circuit_metrics.print();
 
         assert_eq!(Fq12::from_wires(d), c);
     }
@@ -637,9 +637,9 @@ mod tests {
         let c = ark_bn254::Bn254::final_exponentiation(MillerLoopOutput(f))
             .unwrap()
             .0;
-        let (d, gate_count) =
+        let (d, circuit_metrics) =
             final_exponentiation_evaluate_montgomery_fast(Fq12::wires_set_montgomery(f));
-        gate_count.print();
+        circuit_metrics.print();
 
         assert_eq!(Fq12::from_montgomery_wires(d), c);
     }

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -252,10 +252,10 @@ pub trait Fp254Impl {
     }
 
     fn mul_montgomery(a: Wires, b: Wires) -> Circuit {
-        let mul_circuit = U254::mul_karatsuba(a, b);
-        let reduction_circuit = Self::montgomery_reduce(mul_circuit.wires.clone());
-        let mut result_circuit = Circuit::new(reduction_circuit.wires.clone(), mul_circuit.gates());
-        result_circuit.add_gates(reduction_circuit.gates());
+        let mul_circuit = U254::mul(a, b);
+        let reduction_circuit = Self::montgomery_reduce(mul_circuit.wires());
+        let result_circuit = Circuit::new(reduction_circuit.wires(), mul_circuit.gates());
+        result_circuit.gates().extend(reduction_circuit.gates());
         result_circuit
     }
 
@@ -308,9 +308,9 @@ pub trait Fp254Impl {
         }
 
         let mul_circuit = U254::mul_by_constant(a, b.into());
-        let reduction_circuit = Self::montgomery_reduce(mul_circuit.wires.clone());
-        let mut result_circuit = Circuit::new(reduction_circuit.wires.clone(), mul_circuit.gates());
-        result_circuit.add_gates(reduction_circuit.gates());
+        let reduction_circuit = Self::montgomery_reduce(mul_circuit.wires());
+        let result_circuit = Circuit::new(reduction_circuit.wires(), mul_circuit.gates());
+        result_circuit.gates().extend(reduction_circuit.gates());
         result_circuit
     }
 

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -254,8 +254,8 @@ pub trait Fp254Impl {
     fn mul_montgomery(a: Wires, b: Wires) -> Circuit {
         let mul_circuit = U254::mul(a, b);
         let reduction_circuit = Self::montgomery_reduce(mul_circuit.wires());
-        let result_circuit = Circuit::new(reduction_circuit.wires(), mul_circuit.gates());
-        result_circuit.gates().extend(reduction_circuit.gates());
+        let mut result_circuit = Circuit::new(reduction_circuit.wires(), mul_circuit.gates());
+        result_circuit.add_gates(reduction_circuit.gates());
         result_circuit
     }
 
@@ -309,8 +309,8 @@ pub trait Fp254Impl {
 
         let mul_circuit = U254::mul_by_constant(a, b.into());
         let reduction_circuit = Self::montgomery_reduce(mul_circuit.wires());
-        let result_circuit = Circuit::new(reduction_circuit.wires(), mul_circuit.gates());
-        result_circuit.gates().extend(reduction_circuit.gates());
+        let mut result_circuit = Circuit::new(reduction_circuit.wires(), mul_circuit.gates());
+        result_circuit.add_gates(reduction_circuit.gates());
         result_circuit
     }
 

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -253,9 +253,9 @@ pub trait Fp254Impl {
 
     fn mul_montgomery(a: Wires, b: Wires) -> Circuit {
         let mul_circuit = U254::mul_karatsuba(a, b);
-        let reduction_circuit = Self::montgomery_reduce(mul_circuit.0);
-        let mut result_circuit = Circuit::new(reduction_circuit.0, mul_circuit.1);
-        result_circuit.1.extend(reduction_circuit.1);
+        let reduction_circuit = Self::montgomery_reduce(mul_circuit.wires.clone());
+        let mut result_circuit = Circuit::new(reduction_circuit.wires.clone(), mul_circuit.gates());
+        result_circuit.add_gates(reduction_circuit.gates());
         result_circuit
     }
 
@@ -308,9 +308,9 @@ pub trait Fp254Impl {
         }
 
         let mul_circuit = U254::mul_by_constant(a, b.into());
-        let reduction_circuit = Self::montgomery_reduce(mul_circuit.0);
-        let mut result_circuit = Circuit::new(reduction_circuit.0, mul_circuit.1);
-        result_circuit.1.extend(reduction_circuit.1);
+        let reduction_circuit = Self::montgomery_reduce(mul_circuit.wires.clone());
+        let mut result_circuit = Circuit::new(reduction_circuit.wires.clone(), mul_circuit.gates());
+        result_circuit.add_gates(reduction_circuit.gates());
         result_circuit
     }
 

--- a/src/circuits/bn254/fq.rs
+++ b/src/circuits/bn254/fq.rs
@@ -116,10 +116,10 @@ mod tests {
         let b = Fq::random();
         let circuit = Fq::add(Fq::wires_set(a), Fq::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, a + b);
     }
 
@@ -129,10 +129,10 @@ mod tests {
         let b = Fq::random();
         let circuit = Fq::add_constant(Fq::wires_set(a), b);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, a + b);
     }
 
@@ -141,10 +141,10 @@ mod tests {
         let a = Fq::random();
         let circuit = Fq::neg(Fq::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, -a);
     }
 
@@ -154,10 +154,10 @@ mod tests {
         let b = Fq::random();
         let circuit = Fq::sub(Fq::wires_set(a), Fq::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, a - b);
     }
 
@@ -166,10 +166,10 @@ mod tests {
         let a = Fq::random();
         let circuit = Fq::double(Fq::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, a + a);
     }
 
@@ -178,10 +178,10 @@ mod tests {
         let a = Fq::random();
         let circuit = Fq::half(Fq::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c + c, a);
     }
 
@@ -190,10 +190,10 @@ mod tests {
         let a = Fq::random();
         let circuit = Fq::triple(Fq::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, a + a + a);
     }
 
@@ -203,10 +203,10 @@ mod tests {
         let b = Fq::random();
         let circuit = Fq::mul(Fq::wires_set(a), Fq::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, a * b);
     }
 
@@ -219,10 +219,10 @@ mod tests {
             Fq::wires_set(Fq::as_montgomery(b)),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, Fq::as_montgomery(a * b));
     }
 
@@ -232,10 +232,10 @@ mod tests {
         let b = Fq::random();
         let circuit = Fq::mul_by_constant(Fq::wires_set(a), b);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, a * b);
     }
 
@@ -249,28 +249,28 @@ mod tests {
         let circuit =
             Fq::mul_by_constant_montgomery(Fq::wires_set_montgomery(a), Fq::as_montgomery(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let e = Fq::from_wires(circuit.0);
+        let e = Fq::from_wires(circuit.wires);
         assert_eq!(e, Fq::as_montgomery(a * b));
 
         let circuit =
             Fq::mul_by_constant_montgomery(Fq::wires_set_montgomery(a), Fq::as_montgomery(c));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let e = Fq::from_wires(circuit.0);
+        let e = Fq::from_wires(circuit.wires);
         assert_eq!(e, Fq::as_montgomery(a * c));
 
         let circuit =
             Fq::mul_by_constant_montgomery(Fq::wires_set_montgomery(a), Fq::as_montgomery(d));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let e = Fq::from_wires(circuit.0);
+        let e = Fq::from_wires(circuit.wires);
         assert_eq!(e, Fq::as_montgomery(a * d));
     }
 
@@ -279,10 +279,10 @@ mod tests {
         let a = Fq::random();
         let circuit = Fq::square(Fq::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, a * a);
     }
 
@@ -291,10 +291,10 @@ mod tests {
         let a = Fq::random();
         let circuit = Fq::square_montgomery(Fq::wires_set_montgomery(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, Fq::as_montgomery(a * a));
     }
 
@@ -303,10 +303,10 @@ mod tests {
         let a = Fq::random();
         let circuit = Fq::inverse(Fq::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, a.inverse().unwrap());
     }
 
@@ -315,10 +315,10 @@ mod tests {
         let a = Fq::random();
         let circuit = Fq::inverse_montgomery(Fq::wires_set_montgomery(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c, Fq::as_montgomery(a.inverse().unwrap()));
     }
 
@@ -327,11 +327,11 @@ mod tests {
         let a = Fq::random();
         let circuit = Fq::div6(Fq::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
 
-        let c = Fq::from_wires(circuit.0);
+        let c = Fq::from_wires(circuit.wires);
         assert_eq!(c + c + c + c + c + c, a);
     }
 }

--- a/src/circuits/bn254/fq.rs
+++ b/src/circuits/bn254/fq.rs
@@ -115,7 +115,7 @@ mod tests {
         let a = Fq::random();
         let b = Fq::random();
         let circuit = Fq::add(Fq::wires_set(a), Fq::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -128,7 +128,7 @@ mod tests {
         let a = Fq::random();
         let b = Fq::random();
         let circuit = Fq::add_constant(Fq::wires_set(a), b);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -140,7 +140,7 @@ mod tests {
     fn test_fq_neg() {
         let a = Fq::random();
         let circuit = Fq::neg(Fq::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -153,7 +153,7 @@ mod tests {
         let a = Fq::random();
         let b = Fq::random();
         let circuit = Fq::sub(Fq::wires_set(a), Fq::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -165,7 +165,7 @@ mod tests {
     fn test_fq_double() {
         let a = Fq::random();
         let circuit = Fq::double(Fq::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -177,7 +177,7 @@ mod tests {
     fn test_fq_half() {
         let a = Fq::random();
         let circuit = Fq::half(Fq::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -189,7 +189,7 @@ mod tests {
     fn test_fq_triple() {
         let a = Fq::random();
         let circuit = Fq::triple(Fq::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -202,7 +202,7 @@ mod tests {
         let a = Fq::random();
         let b = Fq::random();
         let circuit = Fq::mul(Fq::wires_set(a), Fq::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -218,7 +218,7 @@ mod tests {
             Fq::wires_set(Fq::as_montgomery(a)),
             Fq::wires_set(Fq::as_montgomery(b)),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -231,7 +231,7 @@ mod tests {
         let a = Fq::random();
         let b = Fq::random();
         let circuit = Fq::mul_by_constant(Fq::wires_set(a), b);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -248,7 +248,7 @@ mod tests {
 
         let circuit =
             Fq::mul_by_constant_montgomery(Fq::wires_set_montgomery(a), Fq::as_montgomery(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -257,7 +257,7 @@ mod tests {
 
         let circuit =
             Fq::mul_by_constant_montgomery(Fq::wires_set_montgomery(a), Fq::as_montgomery(c));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -266,7 +266,7 @@ mod tests {
 
         let circuit =
             Fq::mul_by_constant_montgomery(Fq::wires_set_montgomery(a), Fq::as_montgomery(d));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -278,7 +278,7 @@ mod tests {
     fn test_fq_square() {
         let a = Fq::random();
         let circuit = Fq::square(Fq::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -290,7 +290,7 @@ mod tests {
     fn test_fq_square_montgomery() {
         let a = Fq::random();
         let circuit = Fq::square_montgomery(Fq::wires_set_montgomery(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -302,7 +302,7 @@ mod tests {
     fn test_fq_inverse() {
         let a = Fq::random();
         let circuit = Fq::inverse(Fq::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -314,7 +314,7 @@ mod tests {
     fn test_fq_inverse_montgomery() {
         let a = Fq::random();
         let circuit = Fq::inverse_montgomery(Fq::wires_set_montgomery(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -326,7 +326,7 @@ mod tests {
     fn test_fq_div6() {
         let a = Fq::random();
         let circuit = Fq::div6(Fq::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }

--- a/src/circuits/bn254/fq12.rs
+++ b/src/circuits/bn254/fq12.rs
@@ -109,10 +109,10 @@ impl Fq12 {
     pub fn equal_constant_evaluate(a: Wires, b: ark_bn254::Fq12) -> (Wires, GateCount) {
         let circuit = Fq12::equal_constant(a, b);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 
     pub fn add(a: Wires, b: Wires) -> Circuit {
@@ -228,19 +228,19 @@ impl Fq12 {
     pub fn mul_evaluate(a: Wires, b: Wires) -> (Wires, GateCount) {
         let circuit = Fq12::mul(a, b);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 
     pub fn mul_evaluate_montgomery(a: Wires, b: Wires) -> (Wires, GateCount) {
         let circuit = Fq12::mul_montgomery(a, b);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 
     pub fn mul_by_constant(a: Wires, b: ark_bn254::Fq12) -> Circuit {
@@ -509,10 +509,10 @@ impl Fq12 {
     pub fn square_evaluate(a: Wires) -> (Wires, GateCount) {
         let circuit = Fq12::square_montgomery(a);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 
     pub fn cyclotomic_square(a: Wires) -> Circuit {
@@ -724,8 +724,8 @@ impl Fq12 {
             ark_bn254::Fq12Config::FROBENIUS_COEFF_FP12_C1
                 [i % ark_bn254::Fq12Config::FROBENIUS_COEFF_FP12_C1.len()],
         ));
-        circuit.0.extend(frobenius_a_c0);
-        circuit.0.extend(result);
+        circuit.wires.extend(frobenius_a_c0);
+        circuit.wires.extend(result);
         circuit
     }
 
@@ -746,27 +746,27 @@ impl Fq12 {
                     [i % ark_bn254::Fq12Config::FROBENIUS_COEFF_FP12_C1.len()],
             ),
         ));
-        circuit.0.extend(frobenius_a_c0);
-        circuit.0.extend(result);
+        circuit.wires.extend(frobenius_a_c0);
+        circuit.wires.extend(result);
         circuit
     }
 
     pub fn frobenius_evaluate(a: Wires, i: usize) -> (Wires, GateCount) {
         let circuit = Fq12::frobenius(a, i);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 
     pub fn frobenius_evaluate_montgomery(a: Wires, i: usize) -> (Wires, GateCount) {
         let circuit = Fq12::frobenius_montgomery(a, i);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 
     pub fn conjugate(a: Wires) -> Circuit {
@@ -778,18 +778,18 @@ impl Fq12 {
 
         let new_a_c1 = circuit.extend(Fq6::neg(a_c1));
 
-        circuit.0.extend(a_c0);
-        circuit.0.extend(new_a_c1);
+        circuit.wires.extend(a_c0);
+        circuit.wires.extend(new_a_c1);
         circuit
     }
 
     pub fn conjugate_evaluate(a: Wires) -> (Wires, GateCount) {
         let circuit = Fq12::conjugate(a);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 }
 
@@ -818,18 +818,18 @@ mod tests {
         let b = Fq12::random();
         let circuit = Fq12::equal_constant(Fq12::wires_set(a), b);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let result = circuit.0[0].clone().borrow().get_value();
+        let result = circuit.wires[0].clone().borrow().get_value();
         assert_eq!(result, a == b);
 
         let circuit = Fq12::equal_constant(Fq12::wires_set(a), a);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let result = circuit.0[0].clone().borrow().get_value();
+        let result = circuit.wires[0].clone().borrow().get_value();
         assert!(result);
     }
 
@@ -839,10 +839,10 @@ mod tests {
         let b = Fq12::random();
         let circuit = Fq12::add(Fq12::wires_set(a), Fq12::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a + b);
     }
 
@@ -851,10 +851,10 @@ mod tests {
         let a = Fq12::random();
         let circuit = Fq12::neg(Fq12::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, -a);
     }
 
@@ -864,10 +864,10 @@ mod tests {
         let b = Fq12::random();
         let circuit = Fq12::sub(Fq12::wires_set(a), Fq12::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a - b);
     }
 
@@ -876,10 +876,10 @@ mod tests {
         let a = Fq12::random();
         let circuit = Fq12::double(Fq12::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a + a);
     }
 
@@ -890,10 +890,10 @@ mod tests {
         let b = Fq12::random();
         let circuit = Fq12::mul(Fq12::wires_set(a), Fq12::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a * b);
     }
 
@@ -907,10 +907,10 @@ mod tests {
             Fq12::wires_set(Fq12::as_montgomery(b)),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, Fq12::as_montgomery(a * b));
     }
 
@@ -921,10 +921,10 @@ mod tests {
         let b = Fq12::random();
         let circuit = Fq12::mul_by_constant(Fq12::wires_set(a), b);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a * b);
     }
 
@@ -936,10 +936,10 @@ mod tests {
         let circuit =
             Fq12::mul_by_constant_montgomery(Fq12::wires_set_montgomery(a), Fq12::as_montgomery(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, Fq12::as_montgomery(a * b));
     }
 
@@ -951,10 +951,10 @@ mod tests {
         let c4 = Fq2::random();
         let circuit = Fq12::mul_by_34(Fq12::wires_set(a), Fq2::wires_set(c3), Fq2::wires_set(c4));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         let mut b = a;
         b.mul_by_034(&ark_bn254::Fq2::ONE, &c3, &c4);
         assert_eq!(c, b);
@@ -972,10 +972,10 @@ mod tests {
             Fq2::wires_set_montgomery(c4),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         let mut b = a;
         b.mul_by_034(&ark_bn254::Fq2::ONE, &c3, &c4);
         assert_eq!(c, Fq12::as_montgomery(b));
@@ -995,10 +995,10 @@ mod tests {
             Fq2::wires_set(c4),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         let mut b = a;
         b.mul_by_034(&c0, &c3, &c4);
         assert_eq!(c, b);
@@ -1018,10 +1018,10 @@ mod tests {
             Fq2::wires_set_montgomery(c4),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         let mut b = a;
         b.mul_by_034(&c0, &c3, &c4);
         assert_eq!(c, Fq12::as_montgomery(b));
@@ -1033,10 +1033,10 @@ mod tests {
         let a = Fq12::random();
         let circuit = Fq12::square(Fq12::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a * a);
     }
 
@@ -1046,10 +1046,10 @@ mod tests {
         let a = Fq12::random();
         let circuit = Fq12::square_montgomery(Fq12::wires_set_montgomery(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, Fq12::as_montgomery(a * a));
     }
 
@@ -1064,10 +1064,10 @@ mod tests {
         let mut cyclotomic_f = f.pow(u.to_u64_digits());
         let circuit = Fq12::cyclotomic_square(Fq12::wires_set(cyclotomic_f));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         cyclotomic_f.cyclotomic_square_in_place();
         assert_eq!(c, cyclotomic_f);
     }
@@ -1083,10 +1083,10 @@ mod tests {
         let mut cyclotomic_f = f.pow(u.to_u64_digits());
         let circuit = Fq12::cyclotomic_square_montgomery(Fq12::wires_set_montgomery(cyclotomic_f));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         cyclotomic_f.cyclotomic_square_in_place();
         assert_eq!(c, Fq12::as_montgomery(cyclotomic_f));
     }
@@ -1097,10 +1097,10 @@ mod tests {
         let a = Fq12::random();
         let circuit = Fq12::inverse(Fq12::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a.inverse().unwrap());
     }
 
@@ -1110,10 +1110,10 @@ mod tests {
         let a = Fq12::random();
         let circuit = Fq12::inverse_montgomery(Fq12::wires_set_montgomery(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, Fq12::as_montgomery(a.inverse().unwrap()));
     }
 
@@ -1124,34 +1124,34 @@ mod tests {
 
         let circuit = Fq12::frobenius(Fq12::wires_set(a), 0);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a.frobenius_map(0));
 
         let circuit = Fq12::frobenius(Fq12::wires_set(a), 1);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a.frobenius_map(1));
 
         let circuit = Fq12::frobenius(Fq12::wires_set(a), 2);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a.frobenius_map(2));
 
         let circuit = Fq12::frobenius(Fq12::wires_set(a), 3);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, a.frobenius_map(3));
     }
 
@@ -1162,34 +1162,34 @@ mod tests {
 
         let circuit = Fq12::frobenius_montgomery(Fq12::wires_set_montgomery(a), 0);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, Fq12::as_montgomery(a.frobenius_map(0)));
 
         let circuit = Fq12::frobenius(Fq12::wires_set_montgomery(a), 1);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, Fq12::as_montgomery(a.frobenius_map(1)));
 
         let circuit = Fq12::frobenius(Fq12::wires_set_montgomery(a), 2);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, Fq12::as_montgomery(a.frobenius_map(2)));
 
         let circuit = Fq12::frobenius(Fq12::wires_set_montgomery(a), 3);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, Fq12::as_montgomery(a.frobenius_map(3)));
     }
 
@@ -1199,12 +1199,12 @@ mod tests {
 
         let circuit = Fq12::conjugate(Fq12::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
         let mut b = a;
         b.conjugate_in_place();
-        let c = Fq12::from_wires(circuit.0);
+        let c = Fq12::from_wires(circuit.wires);
         assert_eq!(c, b);
     }
 }

--- a/src/circuits/bn254/fq12.rs
+++ b/src/circuits/bn254/fq12.rs
@@ -106,9 +106,9 @@ impl Fq12 {
         circuit
     }
 
-    pub fn equal_constant_evaluate(a: Wires, b: ark_bn254::Fq12) -> (Wires, GateCount) {
+    pub fn equal_constant_evaluate(a: Wires, b: ark_bn254::Fq12) -> (Wires, CircuitMetrics) {
         let circuit = Fq12::equal_constant(a, b);
-        let n = circuit.gate_counts();
+        let n = circuit.circuit_metricss();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -225,18 +225,18 @@ impl Fq12 {
         circuit
     }
 
-    pub fn mul_evaluate(a: Wires, b: Wires) -> (Wires, GateCount) {
+    pub fn mul_evaluate(a: Wires, b: Wires) -> (Wires, CircuitMetrics) {
         let circuit = Fq12::mul(a, b);
-        let n = circuit.gate_counts();
+        let n = circuit.circuit_metricss();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
         (circuit.wires, n)
     }
 
-    pub fn mul_evaluate_montgomery(a: Wires, b: Wires) -> (Wires, GateCount) {
+    pub fn mul_evaluate_montgomery(a: Wires, b: Wires) -> (Wires, CircuitMetrics) {
         let circuit = Fq12::mul_montgomery(a, b);
-        let n = circuit.gate_counts();
+        let n = circuit.circuit_metricss();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -506,9 +506,9 @@ impl Fq12 {
         circuit
     }
 
-    pub fn square_evaluate(a: Wires) -> (Wires, GateCount) {
+    pub fn square_evaluate(a: Wires) -> (Wires, CircuitMetrics) {
         let circuit = Fq12::square_montgomery(a);
-        let n = circuit.gate_counts();
+        let n = circuit.circuit_metricss();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -751,18 +751,18 @@ impl Fq12 {
         circuit
     }
 
-    pub fn frobenius_evaluate(a: Wires, i: usize) -> (Wires, GateCount) {
+    pub fn frobenius_evaluate(a: Wires, i: usize) -> (Wires, CircuitMetrics) {
         let circuit = Fq12::frobenius(a, i);
-        let n = circuit.gate_counts();
+        let n = circuit.circuit_metricss();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
         (circuit.wires, n)
     }
 
-    pub fn frobenius_evaluate_montgomery(a: Wires, i: usize) -> (Wires, GateCount) {
+    pub fn frobenius_evaluate_montgomery(a: Wires, i: usize) -> (Wires, CircuitMetrics) {
         let circuit = Fq12::frobenius_montgomery(a, i);
-        let n = circuit.gate_counts();
+        let n = circuit.circuit_metricss();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -783,9 +783,9 @@ impl Fq12 {
         circuit
     }
 
-    pub fn conjugate_evaluate(a: Wires) -> (Wires, GateCount) {
+    pub fn conjugate_evaluate(a: Wires) -> (Wires, CircuitMetrics) {
         let circuit = Fq12::conjugate(a);
-        let n = circuit.gate_counts();
+        let n = circuit.circuit_metricss();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -817,7 +817,7 @@ mod tests {
         let a = Fq12::random();
         let b = Fq12::random();
         let circuit = Fq12::equal_constant(Fq12::wires_set(a), b);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -825,7 +825,7 @@ mod tests {
         assert_eq!(result, a == b);
 
         let circuit = Fq12::equal_constant(Fq12::wires_set(a), a);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -838,7 +838,7 @@ mod tests {
         let a = Fq12::random();
         let b = Fq12::random();
         let circuit = Fq12::add(Fq12::wires_set(a), Fq12::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -850,7 +850,7 @@ mod tests {
     fn test_fq12_neg() {
         let a = Fq12::random();
         let circuit = Fq12::neg(Fq12::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -863,7 +863,7 @@ mod tests {
         let a = Fq12::random();
         let b = Fq12::random();
         let circuit = Fq12::sub(Fq12::wires_set(a), Fq12::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -875,7 +875,7 @@ mod tests {
     fn test_fq12_double() {
         let a = Fq12::random();
         let circuit = Fq12::double(Fq12::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -889,7 +889,7 @@ mod tests {
         let a = Fq12::random();
         let b = Fq12::random();
         let circuit = Fq12::mul(Fq12::wires_set(a), Fq12::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -906,7 +906,7 @@ mod tests {
             Fq12::wires_set(Fq12::as_montgomery(a)),
             Fq12::wires_set(Fq12::as_montgomery(b)),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -920,7 +920,7 @@ mod tests {
         let a = Fq12::random();
         let b = Fq12::random();
         let circuit = Fq12::mul_by_constant(Fq12::wires_set(a), b);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -935,7 +935,7 @@ mod tests {
         let b = Fq12::random();
         let circuit =
             Fq12::mul_by_constant_montgomery(Fq12::wires_set_montgomery(a), Fq12::as_montgomery(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -950,7 +950,7 @@ mod tests {
         let c3 = Fq2::random();
         let c4 = Fq2::random();
         let circuit = Fq12::mul_by_34(Fq12::wires_set(a), Fq2::wires_set(c3), Fq2::wires_set(c4));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -971,7 +971,7 @@ mod tests {
             Fq2::wires_set_montgomery(c3),
             Fq2::wires_set_montgomery(c4),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -994,7 +994,7 @@ mod tests {
             Fq2::wires_set(c3),
             Fq2::wires_set(c4),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1017,7 +1017,7 @@ mod tests {
             Fq2::wires_set_montgomery(c3),
             Fq2::wires_set_montgomery(c4),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1032,7 +1032,7 @@ mod tests {
     fn test_fq12_square() {
         let a = Fq12::random();
         let circuit = Fq12::square(Fq12::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1045,7 +1045,7 @@ mod tests {
     fn test_fq12_square_montgomery() {
         let a = Fq12::random();
         let circuit = Fq12::square_montgomery(Fq12::wires_set_montgomery(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1063,7 +1063,7 @@ mod tests {
         let f = ark_bn254::Fq12::rand(&mut prng);
         let mut cyclotomic_f = f.pow(u.to_u64_digits());
         let circuit = Fq12::cyclotomic_square(Fq12::wires_set(cyclotomic_f));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1082,7 +1082,7 @@ mod tests {
         let f = ark_bn254::Fq12::rand(&mut prng);
         let mut cyclotomic_f = f.pow(u.to_u64_digits());
         let circuit = Fq12::cyclotomic_square_montgomery(Fq12::wires_set_montgomery(cyclotomic_f));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1096,7 +1096,7 @@ mod tests {
     fn test_fq12_inverse() {
         let a = Fq12::random();
         let circuit = Fq12::inverse(Fq12::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1109,7 +1109,7 @@ mod tests {
     fn test_fq12_inverse_montgomery() {
         let a = Fq12::random();
         let circuit = Fq12::inverse_montgomery(Fq12::wires_set_montgomery(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1123,7 +1123,7 @@ mod tests {
         let a = Fq12::random();
 
         let circuit = Fq12::frobenius(Fq12::wires_set(a), 0);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1131,7 +1131,7 @@ mod tests {
         assert_eq!(c, a.frobenius_map(0));
 
         let circuit = Fq12::frobenius(Fq12::wires_set(a), 1);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1139,7 +1139,7 @@ mod tests {
         assert_eq!(c, a.frobenius_map(1));
 
         let circuit = Fq12::frobenius(Fq12::wires_set(a), 2);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1147,7 +1147,7 @@ mod tests {
         assert_eq!(c, a.frobenius_map(2));
 
         let circuit = Fq12::frobenius(Fq12::wires_set(a), 3);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1161,7 +1161,7 @@ mod tests {
         let a = Fq12::random();
 
         let circuit = Fq12::frobenius_montgomery(Fq12::wires_set_montgomery(a), 0);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1169,7 +1169,7 @@ mod tests {
         assert_eq!(c, Fq12::as_montgomery(a.frobenius_map(0)));
 
         let circuit = Fq12::frobenius(Fq12::wires_set_montgomery(a), 1);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1177,7 +1177,7 @@ mod tests {
         assert_eq!(c, Fq12::as_montgomery(a.frobenius_map(1)));
 
         let circuit = Fq12::frobenius(Fq12::wires_set_montgomery(a), 2);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1185,7 +1185,7 @@ mod tests {
         assert_eq!(c, Fq12::as_montgomery(a.frobenius_map(2)));
 
         let circuit = Fq12::frobenius(Fq12::wires_set_montgomery(a), 3);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1198,7 +1198,7 @@ mod tests {
         let a = Fq12::random();
 
         let circuit = Fq12::conjugate(Fq12::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }

--- a/src/circuits/bn254/fq2.rs
+++ b/src/circuits/bn254/fq2.rs
@@ -448,8 +448,8 @@ impl Fq2 {
             ark_bn254::Fq2Config::FROBENIUS_COEFF_FP2_C1
                 [i % ark_bn254::Fq2Config::FROBENIUS_COEFF_FP2_C1.len()],
         ));
-        circuit.0.extend(a_c0);
-        circuit.0.extend(result);
+        circuit.wires.extend(a_c0);
+        circuit.wires.extend(result);
         circuit
     }
 
@@ -467,8 +467,8 @@ impl Fq2 {
                     [i % ark_bn254::Fq2Config::FROBENIUS_COEFF_FP2_C1.len()],
             ),
         ));
-        circuit.0.extend(a_c0);
-        circuit.0.extend(result);
+        circuit.wires.extend(a_c0);
+        circuit.wires.extend(result);
         circuit
     }
 
@@ -508,10 +508,10 @@ mod tests {
         let b = Fq2::random();
         let circuit = Fq2::add(Fq2::wires_set(a), Fq2::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a + b);
     }
 
@@ -520,10 +520,10 @@ mod tests {
         let a = Fq2::random();
         let circuit = Fq2::neg(Fq2::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, -a);
     }
 
@@ -533,10 +533,10 @@ mod tests {
         let b = Fq2::random();
         let circuit = Fq2::sub(Fq2::wires_set(a), Fq2::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a - b);
     }
 
@@ -545,10 +545,10 @@ mod tests {
         let a = Fq2::random();
         let circuit = Fq2::double(Fq2::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a + a);
     }
 
@@ -557,10 +557,10 @@ mod tests {
         let a = Fq2::random();
         let circuit = Fq2::triple(Fq2::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a + a + a);
     }
 
@@ -570,10 +570,10 @@ mod tests {
         let b = Fq2::random();
         let circuit = Fq2::mul(Fq2::wires_set(a), Fq2::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a * b);
     }
 
@@ -586,10 +586,10 @@ mod tests {
             Fq2::wires_set(Fq2::as_montgomery(b)),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, Fq2::as_montgomery(a * b));
     }
 
@@ -599,10 +599,10 @@ mod tests {
         let b = Fq2::random();
         let circuit = Fq2::mul_by_constant(Fq2::wires_set(a), b);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a * b);
     }
 
@@ -613,10 +613,10 @@ mod tests {
         let circuit =
             Fq2::mul_by_constant_montgomery(Fq2::wires_set_montgomery(a), Fq2::as_montgomery(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, Fq2::as_montgomery(a * b));
     }
 
@@ -626,10 +626,10 @@ mod tests {
         let b = Fq::random();
         let circuit = Fq2::mul_by_fq(Fq2::wires_set(a), Fq::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a * ark_bn254::Fq2::new(b, ark_bn254::Fq::ZERO));
     }
 
@@ -640,10 +640,10 @@ mod tests {
         let circuit =
             Fq2::mul_by_fq_montgomery(Fq2::wires_set_montgomery(a), Fq::wires_set_montgomery(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(
             c,
             Fq2::as_montgomery(a * ark_bn254::Fq2::new(b, ark_bn254::Fq::ZERO))
@@ -656,10 +656,10 @@ mod tests {
         let b = Fq::random();
         let circuit = Fq2::mul_by_constant_fq(Fq2::wires_set(a), b);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a * ark_bn254::Fq2::new(b, ark_bn254::Fq::ZERO));
     }
 
@@ -670,10 +670,10 @@ mod tests {
         let circuit =
             Fq2::mul_by_constant_fq_montgomery(Fq2::wires_set_montgomery(a), Fq::as_montgomery(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(
             c,
             Fq2::as_montgomery(a * ark_bn254::Fq2::new(b, ark_bn254::Fq::ZERO))
@@ -685,10 +685,10 @@ mod tests {
         let a = Fq2::random();
         let circuit = Fq2::mul_by_nonresidue(Fq2::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, ark_bn254::Fq6Config::mul_fp2_by_nonresidue(a));
     }
 
@@ -697,10 +697,10 @@ mod tests {
         let a = Fq2::random();
         let circuit = Fq2::square(Fq2::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a * a);
     }
 
@@ -709,10 +709,10 @@ mod tests {
         let a = Fq2::random();
         let circuit = Fq2::square_montgomery(Fq2::wires_set_montgomery(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, Fq2::as_montgomery(a * a));
     }
 
@@ -721,10 +721,10 @@ mod tests {
         let a = Fq2::random();
         let circuit = Fq2::inverse(Fq2::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a.inverse().unwrap());
     }
 
@@ -733,10 +733,10 @@ mod tests {
         let a = Fq2::random();
         let circuit = Fq2::inverse_montgomery(Fq2::wires_set_montgomery(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, Fq2::as_montgomery(a.inverse().unwrap()));
     }
 
@@ -746,18 +746,18 @@ mod tests {
 
         let circuit = Fq2::frobenius(Fq2::wires_set(a), 0);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a.frobenius_map(0));
 
         let circuit = Fq2::frobenius(Fq2::wires_set(a), 1);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, a.frobenius_map(1));
     }
 
@@ -767,18 +767,18 @@ mod tests {
 
         let circuit = Fq2::frobenius_montgomery(Fq2::wires_set_montgomery(a), 0);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, Fq2::as_montgomery(a.frobenius_map(0)));
 
         let circuit = Fq2::frobenius_montgomery(Fq2::wires_set_montgomery(a), 1);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c, Fq2::as_montgomery(a.frobenius_map(1)));
     }
 
@@ -787,10 +787,10 @@ mod tests {
         let a = Fq2::random();
         let circuit = Fq2::div6(Fq2::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq2::from_wires(circuit.0);
+        let c = Fq2::from_wires(circuit.wires);
         assert_eq!(c + c + c + c + c + c, a);
     }
 }

--- a/src/circuits/bn254/fq2.rs
+++ b/src/circuits/bn254/fq2.rs
@@ -507,7 +507,7 @@ mod tests {
         let a = Fq2::random();
         let b = Fq2::random();
         let circuit = Fq2::add(Fq2::wires_set(a), Fq2::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -519,7 +519,7 @@ mod tests {
     fn test_fq2_neg() {
         let a = Fq2::random();
         let circuit = Fq2::neg(Fq2::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -532,7 +532,7 @@ mod tests {
         let a = Fq2::random();
         let b = Fq2::random();
         let circuit = Fq2::sub(Fq2::wires_set(a), Fq2::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -544,7 +544,7 @@ mod tests {
     fn test_fq2_double() {
         let a = Fq2::random();
         let circuit = Fq2::double(Fq2::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -556,7 +556,7 @@ mod tests {
     fn test_fq2_triple() {
         let a = Fq2::random();
         let circuit = Fq2::triple(Fq2::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -569,7 +569,7 @@ mod tests {
         let a = Fq2::random();
         let b = Fq2::random();
         let circuit = Fq2::mul(Fq2::wires_set(a), Fq2::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -585,7 +585,7 @@ mod tests {
             Fq2::wires_set(Fq2::as_montgomery(a)),
             Fq2::wires_set(Fq2::as_montgomery(b)),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -598,7 +598,7 @@ mod tests {
         let a = Fq2::random();
         let b = Fq2::random();
         let circuit = Fq2::mul_by_constant(Fq2::wires_set(a), b);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -612,7 +612,7 @@ mod tests {
         let b = Fq2::random();
         let circuit =
             Fq2::mul_by_constant_montgomery(Fq2::wires_set_montgomery(a), Fq2::as_montgomery(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -625,7 +625,7 @@ mod tests {
         let a = Fq2::random();
         let b = Fq::random();
         let circuit = Fq2::mul_by_fq(Fq2::wires_set(a), Fq::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -639,7 +639,7 @@ mod tests {
         let b = Fq::random();
         let circuit =
             Fq2::mul_by_fq_montgomery(Fq2::wires_set_montgomery(a), Fq::wires_set_montgomery(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -655,7 +655,7 @@ mod tests {
         let a = Fq2::random();
         let b = Fq::random();
         let circuit = Fq2::mul_by_constant_fq(Fq2::wires_set(a), b);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -669,7 +669,7 @@ mod tests {
         let b = Fq::random();
         let circuit =
             Fq2::mul_by_constant_fq_montgomery(Fq2::wires_set_montgomery(a), Fq::as_montgomery(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -684,7 +684,7 @@ mod tests {
     fn test_fq2_mul_by_nonresiude() {
         let a = Fq2::random();
         let circuit = Fq2::mul_by_nonresidue(Fq2::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -696,7 +696,7 @@ mod tests {
     fn test_fq2_square() {
         let a = Fq2::random();
         let circuit = Fq2::square(Fq2::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -708,7 +708,7 @@ mod tests {
     fn test_fq2_square_montgomery() {
         let a = Fq2::random();
         let circuit = Fq2::square_montgomery(Fq2::wires_set_montgomery(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -720,7 +720,7 @@ mod tests {
     fn test_fq2_inverse() {
         let a = Fq2::random();
         let circuit = Fq2::inverse(Fq2::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -732,7 +732,7 @@ mod tests {
     fn test_fq2_inverse_montgomery() {
         let a = Fq2::random();
         let circuit = Fq2::inverse_montgomery(Fq2::wires_set_montgomery(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -745,7 +745,7 @@ mod tests {
         let a = Fq2::random();
 
         let circuit = Fq2::frobenius(Fq2::wires_set(a), 0);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -753,7 +753,7 @@ mod tests {
         assert_eq!(c, a.frobenius_map(0));
 
         let circuit = Fq2::frobenius(Fq2::wires_set(a), 1);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -766,7 +766,7 @@ mod tests {
         let a = Fq2::random();
 
         let circuit = Fq2::frobenius_montgomery(Fq2::wires_set_montgomery(a), 0);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -774,7 +774,7 @@ mod tests {
         assert_eq!(c, Fq2::as_montgomery(a.frobenius_map(0)));
 
         let circuit = Fq2::frobenius_montgomery(Fq2::wires_set_montgomery(a), 1);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -786,7 +786,7 @@ mod tests {
     fn test_fq2_div6() {
         let a = Fq2::random();
         let circuit = Fq2::div6(Fq2::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }

--- a/src/circuits/bn254/fq6.rs
+++ b/src/circuits/bn254/fq6.rs
@@ -918,7 +918,7 @@ mod tests {
         let a = Fq6::random();
         let b = Fq6::random();
         let circuit = Fq6::add(Fq6::wires_set(a), Fq6::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -930,7 +930,7 @@ mod tests {
     fn test_fq6_neg() {
         let a = Fq6::random();
         let circuit = Fq6::neg(Fq6::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -943,7 +943,7 @@ mod tests {
         let a = Fq6::random();
         let b = Fq6::random();
         let circuit = Fq6::sub(Fq6::wires_set(a), Fq6::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -955,7 +955,7 @@ mod tests {
     fn test_fq6_double() {
         let a = Fq6::random();
         let circuit = Fq6::double(Fq6::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -967,7 +967,7 @@ mod tests {
     fn test_fq6_div6() {
         let a = Fq6::random();
         let circuit = Fq6::div6(Fq6::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -981,7 +981,7 @@ mod tests {
         let a = Fq6::random();
         let b = Fq6::random();
         let circuit = Fq6::mul(Fq6::wires_set(a), Fq6::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -998,7 +998,7 @@ mod tests {
             Fq6::wires_set(Fq6::as_montgomery(a)),
             Fq6::wires_set(Fq6::as_montgomery(b)),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1011,7 +1011,7 @@ mod tests {
         let a = Fq6::random();
         let b = Fq6::random();
         let circuit = Fq6::mul_by_constant(Fq6::wires_set(a), b);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1025,7 +1025,7 @@ mod tests {
         let b = Fq6::random();
         let circuit =
             Fq6::mul_by_constant_montgomery(Fq6::wires_set_montgomery(a), Fq6::as_montgomery(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1038,7 +1038,7 @@ mod tests {
         let a = Fq6::random();
         let b = Fq2::random();
         let circuit = Fq6::mul_by_fq2(Fq6::wires_set(a), Fq2::wires_set(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1055,7 +1055,7 @@ mod tests {
         let b = Fq2::random();
         let circuit =
             Fq6::mul_by_fq2_montgomery(Fq6::wires_set_montgomery(a), Fq2::wires_set_montgomery(b));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1073,7 +1073,7 @@ mod tests {
         let a = Fq6::random();
         let b = Fq2::random();
         let circuit = Fq6::mul_by_constant_fq2(Fq6::wires_set(a), b);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1092,7 +1092,7 @@ mod tests {
             Fq6::wires_set_montgomery(a),
             Fq2::as_montgomery(b),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1109,7 +1109,7 @@ mod tests {
     fn test_fq6_mul_by_nonresidue() {
         let a = Fq6::random();
         let circuit = Fq6::mul_by_nonresidue(Fq6::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1125,7 +1125,7 @@ mod tests {
         let c0 = Fq2::random();
         let c1 = Fq2::random();
         let circuit = Fq6::mul_by_01(Fq6::wires_set(a), Fq2::wires_set(c0), Fq2::wires_set(c1));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1145,7 +1145,7 @@ mod tests {
             Fq2::wires_set_montgomery(c0),
             Fq2::wires_set_montgomery(c1),
         );
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1160,7 +1160,7 @@ mod tests {
     fn test_fq6_square() {
         let a = Fq6::random();
         let circuit = Fq6::square(Fq6::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1173,7 +1173,7 @@ mod tests {
     fn test_fq6_square_montgomery() {
         let a = Fq6::random();
         let circuit = Fq6::square_montgomery(Fq6::wires_set_montgomery(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1186,7 +1186,7 @@ mod tests {
     fn test_fq6_inverse() {
         let a = Fq6::random();
         let circuit = Fq6::inverse(Fq6::wires_set(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1199,7 +1199,7 @@ mod tests {
     fn test_fq6_inverse_montgomery() {
         let a = Fq6::random();
         let circuit = Fq6::inverse_montgomery(Fq6::wires_set_montgomery(a));
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1212,7 +1212,7 @@ mod tests {
         let a = Fq6::random();
 
         let circuit = Fq6::frobenius(Fq6::wires_set(a), 0);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1220,7 +1220,7 @@ mod tests {
         assert_eq!(c, a.frobenius_map(0));
 
         let circuit = Fq6::frobenius(Fq6::wires_set(a), 1);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1233,7 +1233,7 @@ mod tests {
         let a = Fq6::random();
 
         let circuit = Fq6::frobenius_montgomery(Fq6::wires_set_montgomery(a), 0);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }
@@ -1241,7 +1241,7 @@ mod tests {
         assert_eq!(c, Fq6::as_montgomery(a.frobenius_map(0)));
 
         let circuit = Fq6::frobenius_montgomery(Fq6::wires_set_montgomery(a), 1);
-        circuit.gate_counts().print();
+        circuit.circuit_metricss().print();
         for mut gate in circuit.gates() {
             gate.evaluate();
         }

--- a/src/circuits/bn254/fq6.rs
+++ b/src/circuits/bn254/fq6.rs
@@ -861,9 +861,9 @@ impl Fq6 {
             ark_bn254::Fq6Config::FROBENIUS_COEFF_FP6_C2
                 [i % ark_bn254::Fq6Config::FROBENIUS_COEFF_FP6_C2.len()],
         ));
-        circuit.0.extend(frobenius_a_c0);
-        circuit.0.extend(frobenius_a_c1_updated);
-        circuit.0.extend(frobenius_a_c2_updated);
+        circuit.wires.extend(frobenius_a_c0);
+        circuit.wires.extend(frobenius_a_c1_updated);
+        circuit.wires.extend(frobenius_a_c2_updated);
         circuit
     }
 
@@ -890,9 +890,9 @@ impl Fq6 {
                     [i % ark_bn254::Fq6Config::FROBENIUS_COEFF_FP6_C2.len()],
             ),
         ));
-        circuit.0.extend(frobenius_a_c0);
-        circuit.0.extend(frobenius_a_c1_updated);
-        circuit.0.extend(frobenius_a_c2_updated);
+        circuit.wires.extend(frobenius_a_c0);
+        circuit.wires.extend(frobenius_a_c1_updated);
+        circuit.wires.extend(frobenius_a_c2_updated);
         circuit
     }
 }
@@ -919,10 +919,10 @@ mod tests {
         let b = Fq6::random();
         let circuit = Fq6::add(Fq6::wires_set(a), Fq6::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, a + b);
     }
 
@@ -931,10 +931,10 @@ mod tests {
         let a = Fq6::random();
         let circuit = Fq6::neg(Fq6::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, -a);
     }
 
@@ -944,10 +944,10 @@ mod tests {
         let b = Fq6::random();
         let circuit = Fq6::sub(Fq6::wires_set(a), Fq6::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, a - b);
     }
 
@@ -956,10 +956,10 @@ mod tests {
         let a = Fq6::random();
         let circuit = Fq6::double(Fq6::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, a + a);
     }
 
@@ -968,10 +968,10 @@ mod tests {
         let a = Fq6::random();
         let circuit = Fq6::div6(Fq6::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c + c + c + c + c + c, a);
     }
 
@@ -982,10 +982,10 @@ mod tests {
         let b = Fq6::random();
         let circuit = Fq6::mul(Fq6::wires_set(a), Fq6::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, a * b);
     }
 
@@ -999,10 +999,10 @@ mod tests {
             Fq6::wires_set(Fq6::as_montgomery(b)),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, Fq6::as_montgomery(a * b));
     }
 
@@ -1012,10 +1012,10 @@ mod tests {
         let b = Fq6::random();
         let circuit = Fq6::mul_by_constant(Fq6::wires_set(a), b);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, a * b);
     }
 
@@ -1026,10 +1026,10 @@ mod tests {
         let circuit =
             Fq6::mul_by_constant_montgomery(Fq6::wires_set_montgomery(a), Fq6::as_montgomery(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, Fq6::as_montgomery(a * b));
     }
 
@@ -1039,10 +1039,10 @@ mod tests {
         let b = Fq2::random();
         let circuit = Fq6::mul_by_fq2(Fq6::wires_set(a), Fq2::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(
             c,
             a * ark_bn254::Fq6::new(b, ark_bn254::Fq2::ZERO, ark_bn254::Fq2::ZERO)
@@ -1056,10 +1056,10 @@ mod tests {
         let circuit =
             Fq6::mul_by_fq2_montgomery(Fq6::wires_set_montgomery(a), Fq2::wires_set_montgomery(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(
             c,
             Fq6::as_montgomery(
@@ -1074,10 +1074,10 @@ mod tests {
         let b = Fq2::random();
         let circuit = Fq6::mul_by_constant_fq2(Fq6::wires_set(a), b);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(
             c,
             a * ark_bn254::Fq6::new(b, ark_bn254::Fq2::ZERO, ark_bn254::Fq2::ZERO)
@@ -1093,10 +1093,10 @@ mod tests {
             Fq2::as_montgomery(b),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(
             c,
             Fq6::as_montgomery(
@@ -1110,10 +1110,10 @@ mod tests {
         let a = Fq6::random();
         let circuit = Fq6::mul_by_nonresidue(Fq6::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         let mut a_nonresiude = a;
         ark_bn254::Fq12Config::mul_fp6_by_nonresidue_in_place(&mut a_nonresiude);
         assert_eq!(c, a_nonresiude);
@@ -1126,10 +1126,10 @@ mod tests {
         let c1 = Fq2::random();
         let circuit = Fq6::mul_by_01(Fq6::wires_set(a), Fq2::wires_set(c0), Fq2::wires_set(c1));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         let mut b = a;
         b.mul_by_01(&c0, &c1);
         assert_eq!(c, b);
@@ -1146,10 +1146,10 @@ mod tests {
             Fq2::wires_set_montgomery(c1),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         let mut b = a;
         b.mul_by_01(&c0, &c1);
         assert_eq!(c, Fq6::as_montgomery(b));
@@ -1161,10 +1161,10 @@ mod tests {
         let a = Fq6::random();
         let circuit = Fq6::square(Fq6::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, a * a);
     }
 
@@ -1174,10 +1174,10 @@ mod tests {
         let a = Fq6::random();
         let circuit = Fq6::square_montgomery(Fq6::wires_set_montgomery(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, Fq6::as_montgomery(a * a));
     }
 
@@ -1187,10 +1187,10 @@ mod tests {
         let a = Fq6::random();
         let circuit = Fq6::inverse(Fq6::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, a.inverse().unwrap());
     }
 
@@ -1200,10 +1200,10 @@ mod tests {
         let a = Fq6::random();
         let circuit = Fq6::inverse_montgomery(Fq6::wires_set_montgomery(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, Fq6::as_montgomery(a.inverse().unwrap()));
     }
 
@@ -1213,18 +1213,18 @@ mod tests {
 
         let circuit = Fq6::frobenius(Fq6::wires_set(a), 0);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, a.frobenius_map(0));
 
         let circuit = Fq6::frobenius(Fq6::wires_set(a), 1);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, a.frobenius_map(1));
     }
 
@@ -1234,18 +1234,18 @@ mod tests {
 
         let circuit = Fq6::frobenius_montgomery(Fq6::wires_set_montgomery(a), 0);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, Fq6::as_montgomery(a.frobenius_map(0)));
 
         let circuit = Fq6::frobenius_montgomery(Fq6::wires_set_montgomery(a), 1);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = Fq6::from_wires(circuit.0);
+        let c = Fq6::from_wires(circuit.wires);
         assert_eq!(c, Fq6::as_montgomery(a.frobenius_map(1)));
     }
 }

--- a/src/circuits/bn254/g1.rs
+++ b/src/circuits/bn254/g1.rs
@@ -230,19 +230,19 @@ impl G1Projective {
     pub fn add_evaluate(p: Wires, q: Wires) -> (Wires, GateCount) {
         let circuit = Self::add(p, q);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 
     pub fn add_evaluate_montgomery(p: Wires, q: Wires) -> (Wires, GateCount) {
         let circuit = Self::add_montgomery(p, q);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 
     pub fn double(p: Wires) -> Circuit {
@@ -342,10 +342,10 @@ impl G1Projective {
     pub fn multiplexer_evaluate(a: Vec<Wires>, s: Wires, w: usize) -> (Wires, GateCount) {
         let circuit = Self::multiplexer(a, s, w);
         let n = circuit.gate_counts();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        (circuit.0, n)
+        (circuit.wires, n)
     }
 
     pub fn scalar_mul_by_constant_base<const W: usize>(
@@ -671,10 +671,10 @@ pub fn projective_to_affine(p: Wires) -> Circuit {
 pub fn projective_to_affine_evaluate(p: Wires) -> (Wires, GateCount) {
     let circuit = projective_to_affine(p);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    (circuit.0, n)
+    (circuit.wires, n)
 }
 
 pub fn projective_to_affine_montgomery(p: Wires) -> Circuit {
@@ -700,10 +700,10 @@ pub fn projective_to_affine_montgomery(p: Wires) -> Circuit {
 pub fn projective_to_affine_evaluate_montgomery(p: Wires) -> (Wires, GateCount) {
     let circuit = projective_to_affine_montgomery(p);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    (circuit.0, n)
+    (circuit.wires, n)
 }
 
 #[cfg(test)]
@@ -740,10 +740,10 @@ mod tests {
         let p_affine = p_projective.into_affine();
         let circuit = projective_to_affine(G1Projective::wires_set(p_projective));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let p_affine2 = G1Affine::from_wires(circuit.0);
+        let p_affine2 = G1Affine::from_wires(circuit.wires);
         assert_eq!(p_affine, p_affine2);
     }
 
@@ -755,10 +755,10 @@ mod tests {
         let circuit =
             projective_to_affine_montgomery(G1Projective::wires_set_montgomery(p_projective));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let p_affine2 = G1Affine::from_montgomery_wires_unchecked(circuit.0);
+        let p_affine2 = G1Affine::from_montgomery_wires_unchecked(circuit.wires);
         assert_eq!(p_affine, p_affine2);
     }
 
@@ -770,31 +770,31 @@ mod tests {
         let c = ark_bn254::G1Projective::ZERO;
         let circuit = G1Projective::add(G1Projective::wires_set(a), G1Projective::wires_set(b));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let d = G1Projective::from_wires(circuit.0);
+        let d = G1Projective::from_wires(circuit.wires);
         assert_eq!(d, a + b);
 
         let circuit = G1Projective::add(G1Projective::wires_set(a), G1Projective::wires_set(c));
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let d = G1Projective::from_wires(circuit.0);
+        let d = G1Projective::from_wires(circuit.wires);
         assert_eq!(d, a);
 
         let circuit = G1Projective::add(G1Projective::wires_set(c), G1Projective::wires_set(b));
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let d = G1Projective::from_wires(circuit.0);
+        let d = G1Projective::from_wires(circuit.wires);
         assert_eq!(d, b);
 
         let circuit = G1Projective::add(G1Projective::wires_set(c), G1Projective::wires_set(c));
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let d = G1Projective::from_wires(circuit.0);
+        let d = G1Projective::from_wires(circuit.wires);
         assert_eq!(d, c);
     }
 
@@ -809,40 +809,40 @@ mod tests {
             G1Projective::wires_set_montgomery(b),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let d = G1Projective::from_wires_unchecked(circuit.0);
+        let d = G1Projective::from_wires_unchecked(circuit.wires);
         assert_eq!(d, G1Projective::as_montgomery(a + b));
 
         let circuit = G1Projective::add(
             G1Projective::wires_set_montgomery(a),
             G1Projective::wires_set_montgomery(c),
         );
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let d = G1Projective::from_wires_unchecked(circuit.0);
+        let d = G1Projective::from_wires_unchecked(circuit.wires);
         assert_eq!(d, G1Projective::as_montgomery(a));
 
         let circuit = G1Projective::add(
             G1Projective::wires_set_montgomery(c),
             G1Projective::wires_set_montgomery(b),
         );
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let d = G1Projective::from_wires_unchecked(circuit.0);
+        let d = G1Projective::from_wires_unchecked(circuit.wires);
         assert_eq!(d, G1Projective::as_montgomery(b));
 
         let circuit = G1Projective::add(
             G1Projective::wires_set_montgomery(c),
             G1Projective::wires_set_montgomery(c),
         );
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let d = G1Projective::from_wires_unchecked(circuit.0);
+        let d = G1Projective::from_wires_unchecked(circuit.wires);
         assert_eq!(d, G1Projective::as_montgomery(c));
     }
 
@@ -875,18 +875,18 @@ mod tests {
         let a = G1Projective::random();
         let circuit = G1Projective::double(G1Projective::wires_set(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = G1Projective::from_wires(circuit.0);
+        let c = G1Projective::from_wires(circuit.wires);
         assert_eq!(c, a + a);
 
         let b = ark_bn254::G1Projective::ZERO;
         let circuit = G1Projective::double(G1Projective::wires_set(b));
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = G1Projective::from_wires(circuit.0);
+        let c = G1Projective::from_wires(circuit.wires);
         assert_eq!(c, b);
     }
 
@@ -895,18 +895,18 @@ mod tests {
         let a = G1Projective::random();
         let circuit = G1Projective::double_montgomery(G1Projective::wires_set_montgomery(a));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = G1Projective::from_wires_unchecked(circuit.0);
+        let c = G1Projective::from_wires_unchecked(circuit.wires);
         assert_eq!(c, G1Projective::as_montgomery(a + a));
 
         let b = ark_bn254::G1Projective::ZERO;
         let circuit = G1Projective::double(G1Projective::wires_set_montgomery(b));
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c = G1Projective::from_wires_unchecked(circuit.0);
+        let c = G1Projective::from_wires_unchecked(circuit.wires);
         assert_eq!(c, G1Projective::as_montgomery(b));
     }
 
@@ -933,11 +933,11 @@ mod tests {
         let circuit = G1Projective::multiplexer(a_wires, s.clone(), w);
         circuit.gate_counts().print();
 
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
 
-        let result = G1Projective::from_wires(circuit.0);
+        let result = G1Projective::from_wires(circuit.wires);
         let expected = a[u];
 
         assert_eq!(result, expected);
@@ -977,10 +977,10 @@ mod tests {
         let s = Fr::random();
         let circuit = G1Projective::scalar_mul_by_constant_base::<10>(Fr::wires_set(s), base);
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let result = G1Projective::from_wires(circuit.0);
+        let result = G1Projective::from_wires(circuit.wires);
         assert_eq!(result, base * s);
     }
 

--- a/src/circuits/bn254/pairing.rs
+++ b/src/circuits/bn254/pairing.rs
@@ -161,26 +161,26 @@ pub fn double_in_place_circuit_montgomery(r: Wires) -> Circuit {
 pub fn double_in_place_evaluate(r: Wires) -> ((Wires, Wires, Wires), Wires, GateCount) {
     let circuit = double_in_place_circuit(r);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    let c0 = circuit.0[0..Fq2::N_BITS].to_vec();
-    let c1 = circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
-    let c2 = circuit.0[Fq2::N_BITS * 2..Fq2::N_BITS * 3].to_vec();
-    let r = circuit.0[Fq2::N_BITS * 3..Fq2::N_BITS * 6].to_vec();
+    let c0 = circuit.wires[0..Fq2::N_BITS].to_vec();
+    let c1 = circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
+    let c2 = circuit.wires[Fq2::N_BITS * 2..Fq2::N_BITS * 3].to_vec();
+    let r = circuit.wires[Fq2::N_BITS * 3..Fq2::N_BITS * 6].to_vec();
     ((c0, c1, c2), r, n)
 }
 
 pub fn double_in_place_evaluate_montgomery(r: Wires) -> ((Wires, Wires, Wires), Wires, GateCount) {
     let circuit = double_in_place_circuit_montgomery(r);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    let c0 = circuit.0[0..Fq2::N_BITS].to_vec();
-    let c1 = circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
-    let c2 = circuit.0[Fq2::N_BITS * 2..Fq2::N_BITS * 3].to_vec();
-    let r = circuit.0[Fq2::N_BITS * 3..Fq2::N_BITS * 6].to_vec();
+    let c0 = circuit.wires[0..Fq2::N_BITS].to_vec();
+    let c1 = circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
+    let c2 = circuit.wires[Fq2::N_BITS * 2..Fq2::N_BITS * 3].to_vec();
+    let r = circuit.wires[Fq2::N_BITS * 3..Fq2::N_BITS * 6].to_vec();
     ((c0, c1, c2), r, n)
 }
 
@@ -343,13 +343,13 @@ pub fn add_in_place_circuit_montgomery(r: Wires, q: Wires) -> Circuit {
 pub fn add_in_place_evaluate(r: Wires, q: Wires) -> ((Wires, Wires, Wires), Wires, GateCount) {
     let circuit = add_in_place_circuit(r, q);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    let c0 = circuit.0[0..Fq2::N_BITS].to_vec();
-    let c1 = circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
-    let c2 = circuit.0[Fq2::N_BITS * 2..Fq2::N_BITS * 3].to_vec();
-    let r = circuit.0[Fq2::N_BITS * 3..Fq2::N_BITS * 6].to_vec();
+    let c0 = circuit.wires[0..Fq2::N_BITS].to_vec();
+    let c1 = circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
+    let c2 = circuit.wires[Fq2::N_BITS * 2..Fq2::N_BITS * 3].to_vec();
+    let r = circuit.wires[Fq2::N_BITS * 3..Fq2::N_BITS * 6].to_vec();
     ((c0, c1, c2), r, n)
 }
 
@@ -359,13 +359,13 @@ pub fn add_in_place_evaluate_montgomery(
 ) -> ((Wires, Wires, Wires), Wires, GateCount) {
     let circuit = add_in_place_circuit_montgomery(r, q);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    let c0 = circuit.0[0..Fq2::N_BITS].to_vec();
-    let c1 = circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
-    let c2 = circuit.0[Fq2::N_BITS * 2..Fq2::N_BITS * 3].to_vec();
-    let r = circuit.0[Fq2::N_BITS * 3..Fq2::N_BITS * 6].to_vec();
+    let c0 = circuit.wires[0..Fq2::N_BITS].to_vec();
+    let c1 = circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec();
+    let c2 = circuit.wires[Fq2::N_BITS * 2..Fq2::N_BITS * 3].to_vec();
+    let r = circuit.wires[Fq2::N_BITS * 3..Fq2::N_BITS * 6].to_vec();
     ((c0, c1, c2), r, n)
 }
 
@@ -421,19 +421,19 @@ pub fn mul_by_char_circuit_montgomery(r: Wires) -> Circuit {
 pub fn mul_by_char_evaluate(r: Wires) -> (Wires, GateCount) {
     let circuit = mul_by_char_circuit(r);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    (circuit.0, n)
+    (circuit.wires, n)
 }
 
 pub fn mul_by_char_evaluate_montgomery(r: Wires) -> (Wires, GateCount) {
     let circuit = mul_by_char_circuit_montgomery(r);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    (circuit.0, n)
+    (circuit.wires, n)
 }
 
 pub fn g2_affine_neg_evaluate(r: Wires) -> (Wires, GateCount) {
@@ -444,10 +444,10 @@ pub fn g2_affine_neg_evaluate(r: Wires) -> (Wires, GateCount) {
     circuit.add_wires(x);
     circuit.add_wires(new_y);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    (circuit.0, n)
+    (circuit.wires, n)
 }
 
 pub fn ell_coeffs(q: ark_bn254::G2Affine) -> Vec<(ark_bn254::Fq2, ark_bn254::Fq2, ark_bn254::Fq2)> {
@@ -786,10 +786,10 @@ pub fn ell_circuit_montgomery(f: Wires, coeffs: (Wires, Wires, Wires), p: Wires)
 pub fn ell_evaluate(f: Wires, coeffs: (Wires, Wires, Wires), p: Wires) -> (Wires, GateCount) {
     let circuit = ell_circuit(f, coeffs, p);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    (circuit.0, n)
+    (circuit.wires, n)
 }
 
 pub fn ell_evaluate_montgomery(
@@ -799,10 +799,10 @@ pub fn ell_evaluate_montgomery(
 ) -> (Wires, GateCount) {
     let circuit = ell_circuit_montgomery(f, coeffs, p);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    (circuit.0, n)
+    (circuit.wires, n)
 }
 
 pub fn ell_by_constant_circuit(
@@ -854,10 +854,10 @@ pub fn ell_by_constant_evaluate(
 ) -> (Wires, GateCount) {
     let circuit = ell_by_constant_circuit(f, coeffs, p);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    (circuit.0, n)
+    (circuit.wires, n)
 }
 
 pub fn ell_by_constant_evaluate_montgomery(
@@ -867,10 +867,10 @@ pub fn ell_by_constant_evaluate_montgomery(
 ) -> (Wires, GateCount) {
     let circuit = ell_by_constant_circuit_montgomery(f, coeffs, p);
     let n = circuit.gate_counts();
-    for mut gate in circuit.1 {
+    for mut gate in circuit.gates() {
         gate.evaluate();
     }
-    (circuit.0, n)
+    (circuit.wires, n)
 }
 
 pub fn miller_loop(p: ark_bn254::G1Affine, q: ark_bn254::G2Affine) -> ark_bn254::Fq12 {
@@ -1751,15 +1751,15 @@ mod tests {
 
         let circuit = double_in_place_circuit(G2Projective::wires_set(r));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c0 = Fq2::from_wires(circuit.0[0..Fq2::N_BITS].to_vec());
-        let c1 = Fq2::from_wires(circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
-        let c2 = Fq2::from_wires(circuit.0[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec());
-        let rx = Fq2::from_wires(circuit.0[3 * Fq2::N_BITS..4 * Fq2::N_BITS].to_vec());
-        let ry = Fq2::from_wires(circuit.0[4 * Fq2::N_BITS..5 * Fq2::N_BITS].to_vec());
-        let rz = Fq2::from_wires(circuit.0[5 * Fq2::N_BITS..6 * Fq2::N_BITS].to_vec());
+        let c0 = Fq2::from_wires(circuit.wires[0..Fq2::N_BITS].to_vec());
+        let c1 = Fq2::from_wires(circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
+        let c2 = Fq2::from_wires(circuit.wires[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec());
+        let rx = Fq2::from_wires(circuit.wires[3 * Fq2::N_BITS..4 * Fq2::N_BITS].to_vec());
+        let ry = Fq2::from_wires(circuit.wires[4 * Fq2::N_BITS..5 * Fq2::N_BITS].to_vec());
+        let rz = Fq2::from_wires(circuit.wires[5 * Fq2::N_BITS..6 * Fq2::N_BITS].to_vec());
         let coeffs = double_in_place(&mut r);
         assert_eq!(c0, coeffs.0);
         assert_eq!(c1, coeffs.1);
@@ -1777,15 +1777,19 @@ mod tests {
 
         let circuit = double_in_place_circuit_montgomery(G2Projective::wires_set_montgomery(r));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c0 = Fq2::from_montgomery_wires(circuit.0[0..Fq2::N_BITS].to_vec());
-        let c1 = Fq2::from_montgomery_wires(circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
-        let c2 = Fq2::from_montgomery_wires(circuit.0[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec());
-        let rx = Fq2::from_montgomery_wires(circuit.0[3 * Fq2::N_BITS..4 * Fq2::N_BITS].to_vec());
-        let ry = Fq2::from_montgomery_wires(circuit.0[4 * Fq2::N_BITS..5 * Fq2::N_BITS].to_vec());
-        let rz = Fq2::from_montgomery_wires(circuit.0[5 * Fq2::N_BITS..6 * Fq2::N_BITS].to_vec());
+        let c0 = Fq2::from_montgomery_wires(circuit.wires[0..Fq2::N_BITS].to_vec());
+        let c1 = Fq2::from_montgomery_wires(circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
+        let c2 =
+            Fq2::from_montgomery_wires(circuit.wires[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec());
+        let rx =
+            Fq2::from_montgomery_wires(circuit.wires[3 * Fq2::N_BITS..4 * Fq2::N_BITS].to_vec());
+        let ry =
+            Fq2::from_montgomery_wires(circuit.wires[4 * Fq2::N_BITS..5 * Fq2::N_BITS].to_vec());
+        let rz =
+            Fq2::from_montgomery_wires(circuit.wires[5 * Fq2::N_BITS..6 * Fq2::N_BITS].to_vec());
         let coeffs = double_in_place(&mut r);
         assert_eq!(c0, coeffs.0);
         assert_eq!(c1, coeffs.1);
@@ -1804,19 +1808,20 @@ mod tests {
 
         let circuit = add_in_place_circuit(G2Projective::wires_set(r), G2Affine::wires_set(q));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c0 = Fq2::from_wires(circuit.0[0..Fq2::N_BITS].to_vec());
-        let c1 = Fq2::from_wires(circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
-        let c2 = Fq2::from_wires(circuit.0[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec());
+        let c0 = Fq2::from_wires(circuit.wires[0..Fq2::N_BITS].to_vec());
+        let c1 = Fq2::from_wires(circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
+        let c2 = Fq2::from_wires(circuit.wires[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec());
         let new_r_x =
-            Fq2::from_wires(circuit.0[3 * Fq2::N_BITS..3 * Fq2::N_BITS + Fq2::N_BITS].to_vec());
+            Fq2::from_wires(circuit.wires[3 * Fq2::N_BITS..3 * Fq2::N_BITS + Fq2::N_BITS].to_vec());
         let new_r_y = Fq2::from_wires(
-            circuit.0[3 * Fq2::N_BITS + Fq2::N_BITS..3 * Fq2::N_BITS + 2 * Fq2::N_BITS].to_vec(),
+            circuit.wires[3 * Fq2::N_BITS + Fq2::N_BITS..3 * Fq2::N_BITS + 2 * Fq2::N_BITS]
+                .to_vec(),
         );
         let new_r_z = Fq2::from_wires(
-            circuit.0[3 * Fq2::N_BITS + 2 * Fq2::N_BITS..3 * Fq2::N_BITS + 3 * Fq2::N_BITS]
+            circuit.wires[3 * Fq2::N_BITS + 2 * Fq2::N_BITS..3 * Fq2::N_BITS + 3 * Fq2::N_BITS]
                 .to_vec(),
         );
         let coeffs = add_in_place(&mut r, &q);
@@ -1840,20 +1845,22 @@ mod tests {
             G2Affine::wires_set_montgomery(q),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c0 = Fq2::from_montgomery_wires(circuit.0[0..Fq2::N_BITS].to_vec());
-        let c1 = Fq2::from_montgomery_wires(circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
-        let c2 = Fq2::from_montgomery_wires(circuit.0[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec());
+        let c0 = Fq2::from_montgomery_wires(circuit.wires[0..Fq2::N_BITS].to_vec());
+        let c1 = Fq2::from_montgomery_wires(circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
+        let c2 =
+            Fq2::from_montgomery_wires(circuit.wires[2 * Fq2::N_BITS..3 * Fq2::N_BITS].to_vec());
         let new_r_x = Fq2::from_montgomery_wires(
-            circuit.0[3 * Fq2::N_BITS..3 * Fq2::N_BITS + Fq2::N_BITS].to_vec(),
+            circuit.wires[3 * Fq2::N_BITS..3 * Fq2::N_BITS + Fq2::N_BITS].to_vec(),
         );
         let new_r_y = Fq2::from_montgomery_wires(
-            circuit.0[3 * Fq2::N_BITS + Fq2::N_BITS..3 * Fq2::N_BITS + 2 * Fq2::N_BITS].to_vec(),
+            circuit.wires[3 * Fq2::N_BITS + Fq2::N_BITS..3 * Fq2::N_BITS + 2 * Fq2::N_BITS]
+                .to_vec(),
         );
         let new_r_z = Fq2::from_montgomery_wires(
-            circuit.0[3 * Fq2::N_BITS + 2 * Fq2::N_BITS..3 * Fq2::N_BITS + 3 * Fq2::N_BITS]
+            circuit.wires[3 * Fq2::N_BITS + 2 * Fq2::N_BITS..3 * Fq2::N_BITS + 3 * Fq2::N_BITS]
                 .to_vec(),
         );
         let coeffs = add_in_place(&mut r, &q);
@@ -1873,11 +1880,11 @@ mod tests {
 
         let circuit = mul_by_char_circuit(G2Affine::wires_set(q));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c0 = Fq2::from_wires(circuit.0[0..Fq2::N_BITS].to_vec());
-        let c1 = Fq2::from_wires(circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
+        let c0 = Fq2::from_wires(circuit.wires[0..Fq2::N_BITS].to_vec());
+        let c1 = Fq2::from_wires(circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
         let coeffs = mul_by_char(q);
         assert_eq!(c0, coeffs.x);
         assert_eq!(c1, coeffs.y);
@@ -1891,11 +1898,11 @@ mod tests {
 
         let circuit = mul_by_char_circuit_montgomery(G2Affine::wires_set_montgomery(q));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let c0 = Fq2::from_montgomery_wires(circuit.0[0..Fq2::N_BITS].to_vec());
-        let c1 = Fq2::from_montgomery_wires(circuit.0[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
+        let c0 = Fq2::from_montgomery_wires(circuit.wires[0..Fq2::N_BITS].to_vec());
+        let c1 = Fq2::from_montgomery_wires(circuit.wires[Fq2::N_BITS..2 * Fq2::N_BITS].to_vec());
         let coeffs = mul_by_char(q);
         assert_eq!(c0, coeffs.x);
         assert_eq!(c1, coeffs.y);
@@ -1956,10 +1963,10 @@ mod tests {
             G1Affine::wires_set(p),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let new_f = Fq12::from_wires(circuit.0);
+        let new_f = Fq12::from_wires(circuit.wires);
         ell(&mut f, coeffs, p);
         assert_eq!(f, new_f);
     }
@@ -1986,10 +1993,10 @@ mod tests {
             G1Affine::wires_set_montgomery(p),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let new_f = Fq12::from_montgomery_wires(circuit.0);
+        let new_f = Fq12::from_montgomery_wires(circuit.wires);
         ell(&mut f, coeffs, p);
         assert_eq!(f, new_f);
     }
@@ -2008,10 +2015,10 @@ mod tests {
 
         let circuit = ell_by_constant_circuit(Fq12::wires_set(f), coeffs, G1Affine::wires_set(p));
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let new_f = Fq12::from_wires(circuit.0);
+        let new_f = Fq12::from_wires(circuit.wires);
         ell(&mut f, coeffs, p);
         assert_eq!(f, new_f);
     }
@@ -2038,10 +2045,10 @@ mod tests {
             G1Affine::wires_set_montgomery(p),
         );
         circuit.gate_counts().print();
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
-        let new_f = Fq12::from_montgomery_wires(circuit.0);
+        let new_f = Fq12::from_montgomery_wires(circuit.wires);
         ell(&mut f, coeffs, p);
         assert_eq!(f, new_f);
     }

--- a/src/core/bristol.rs
+++ b/src/core/bristol.rs
@@ -105,7 +105,7 @@ mod tests {
         for (i, wire) in inputs[1].iter().enumerate() {
             wire.borrow_mut().set((b >> i) & 1 == 1);
         }
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
         let mut result_bits = Vec::new();
@@ -130,7 +130,7 @@ mod tests {
         for (i, wire) in inputs[1].iter().enumerate() {
             wire.borrow_mut().set((b >> i) & 1 == 1);
         }
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
         let mut result_bits = Vec::new();
@@ -155,7 +155,7 @@ mod tests {
         for (i, wire) in inputs[1].iter().enumerate() {
             wire.borrow_mut().set((b >> i) & 1 == 1);
         }
-        for mut gate in circuit.1 {
+        for mut gate in circuit.gates() {
             gate.evaluate();
         }
         let mut result_bits = Vec::new();

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -1,12 +1,12 @@
 use crate::{bag::*, core::gate::CircuitMetrics};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
-pub type GatesMap = HashMap<u64, Gate>;
+pub type GatesMap = BTreeMap<u64, Gate>;
 
 pub struct Circuit {
     pub wires: Wires,
     pub gates: GatesMap,
-    wires2gates: HashMap<S, Vec<u64>>, // maps wire index to fan-out gates indexs
+    wires2gates: BTreeMap<S, Vec<u64>>, // maps wire index to fan-out gates indexs
     gates_num: u64,
 }
 
@@ -14,8 +14,8 @@ impl Circuit {
     pub fn empty() -> Self {
         Self {
             wires: Vec::new(),
-            gates: HashMap::new(),
-            wires2gates: HashMap::new(),
+            gates: BTreeMap::new(),
+            wires2gates: BTreeMap::new(),
             gates_num: 0,
         }
     }

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -8,6 +8,8 @@ pub struct Circuit {
     gates_num: u64,
 }
 
+const FANOUT_SWITCHER: bool = false;
+
 impl Circuit {
     pub fn empty() -> Self {
         Self {
@@ -40,12 +42,14 @@ impl Circuit {
     }
 
     pub fn add(&mut self, gate: Gate) {
-        for wire in [gate.wire_a.clone(), gate.wire_b.clone()] {
-            let wire_index = wire.borrow().get_label0(); // use the label0 as index
-            self.wires2gates
-                .entry(wire_index)
-                .or_insert_with(Vec::new)
-                .push(self.gates_num);
+        if FANOUT_SWITCHER {
+            for wire in [gate.wire_a.clone(), gate.wire_b.clone()] {
+                let wire_index = wire.borrow().get_label0(); // use the label0 as index
+                self.wires2gates
+                    .entry(wire_index)
+                    .or_insert_with(Vec::new)
+                    .push(self.gates_num);
+            }
         }
         self.gates.push(gate);
         self.gates_num += 1;

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -67,6 +67,14 @@ impl Circuit {
         self.gates.len()
     }
 
+    pub fn gates(&self) -> Vec<Gate> {
+        self.gates.iter().map(|(_, gate)| gate.clone()).collect()
+    }
+
+    pub fn wires(&self) -> Wires {
+        self.wires.clone()
+    }
+
     pub fn gate_counts(&self) -> GateCount {
         let mut and = 0;
         let mut or = 0;
@@ -135,7 +143,7 @@ mod tests {
             if correct { "correct" } else { "incorrect" }
         );
 
-        for (i, (gate, garble)) in zip(circuit.1.clone(), garbled_gates).enumerate() {
+        for (i, (gate, garble)) in zip(circuit.gates().clone(), garbled_gates).enumerate() {
             let a = gate.wire_a.borrow().get_label();
             let b = gate.wire_b.borrow().get_label();
             let bit_a = gate.wire_a.borrow().get_value();
@@ -193,7 +201,7 @@ mod tests {
             if correct { "correct" } else { "incorrect" }
         );
 
-        for (i, (gate, garble)) in zip(circuit.1.clone(), garbled_gates).enumerate() {
+        for (i, (gate, garble)) in zip(circuit.gates().clone(), garbled_gates).enumerate() {
             let a = gate.wire_a.borrow().get_label();
             let b = gate.wire_b.borrow().get_label();
             let bit_a = gate.wire_a.borrow().get_value();

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -81,12 +81,20 @@ impl Circuit {
         self.wires.clone()
     }
 
-    pub fn fanout(&self) -> usize {
-        let mut fanout = 0;
+    pub fn fanout(&self) -> (usize, usize, usize) {
+        let mut fanout1 = 0;
+        let mut fanout2 = 0;
+        let mut fanoutmore = 0;
         for gates in self.wires2gates.values() {
-            fanout += gates.len();
+            if gates.len() == 1 {
+                fanout1 += 1;
+            } else if gates.len() == 2 {
+                fanout2 += 1;
+            } else {
+                fanoutmore += 1;
+            }
         }
-        fanout
+        (fanout1, fanout2, fanoutmore)
     }
 
     pub fn circuit_metricss(&self) -> CircuitMetrics {

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -1,4 +1,4 @@
-use crate::{bag::*, core::gate::GateCount};
+use crate::{bag::*, core::gate::CircuitMetrics};
 use std::collections::HashMap;
 
 pub type GatesMap = HashMap<u64, Gate>;
@@ -63,7 +63,7 @@ impl Circuit {
         }
     }
 
-    pub fn gate_count(&self) -> usize {
+    pub fn circuit_metrics(&self) -> usize {
         self.gates.len()
     }
 
@@ -83,7 +83,7 @@ impl Circuit {
         fanout
     }
 
-    pub fn gate_counts(&self) -> GateCount {
+    pub fn circuit_metricss(&self) -> CircuitMetrics {
         let mut and = 0;
         let mut or = 0;
         let mut xor = 0;
@@ -105,7 +105,7 @@ impl Circuit {
                 _ => panic!("this gate type is not allowed"),
             }
         }
-        GateCount {
+        CircuitMetrics {
             and,
             or,
             xor,
@@ -114,6 +114,7 @@ impl Circuit {
             xnor,
             nimp,
             nsor,
+            fanout: self.fanout(),
         }
     }
 }

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -75,6 +75,14 @@ impl Circuit {
         self.wires.clone()
     }
 
+    pub fn fanout(&self) -> usize {
+        let mut fanout = 0;
+        for gates in self.wires2gates.values() {
+            fanout += gates.len();
+        }
+        fanout
+    }
+
     pub fn gate_counts(&self) -> GateCount {
         let mut and = 0;
         let mut or = 0;

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -35,7 +35,7 @@ impl Circuit {
 
     /// add gates from a circuit, return the wires of the circuit
     pub fn extend(&mut self, circuit: Self) -> Wires {
-        for (_, gate) in circuit.gates {
+        for (_, gate) in circuit.gates.into_iter() {
             self.add(gate);
         }
         circuit.wires
@@ -60,6 +60,12 @@ impl Circuit {
     pub fn add_wires(&mut self, wires: Wires) {
         for wire in wires {
             self.add_wire(wire);
+        }
+    }
+
+    pub fn add_gates(&mut self, gates: Vec<Gate>) {
+        for gate in gates {
+            self.add(gate);
         }
     }
 

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -365,7 +365,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (355478375, 256478600, 52018654),
         }
     }
 
@@ -380,7 +380,7 @@ impl CircuitMetrics {
             nimp: 1078400,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (186431575, 158753800, 610654),
         }
     }
 
@@ -395,7 +395,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (19874796, 19710410, 4025178),
         }
     }
 
@@ -410,7 +410,7 @@ impl CircuitMetrics {
             nimp: 80880,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (7196286, 12381050, 169578),
         }
     }
 
@@ -425,7 +425,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (11842134, 11778021, 2394337),
         }
     }
 
@@ -440,7 +440,7 @@ impl CircuitMetrics {
             nimp: 48528,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (4235028, 7380405, 80977),
         }
     }
 
@@ -455,7 +455,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (29762349, 29516821, 6031569),
         }
     }
 
@@ -470,7 +470,7 @@ impl CircuitMetrics {
             nimp: 121320,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (10744584, 18522781, 248169),
         }
     }
 
@@ -485,7 +485,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (27956519, 27819485, 5654355),
         }
     }
 
@@ -500,7 +500,7 @@ impl CircuitMetrics {
             nimp: 240452,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (33922273, 46541956, 1750809),
         }
     }
 
@@ -515,7 +515,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (14974820, 14704029, 3045307),
         }
     }
 
@@ -530,7 +530,7 @@ impl CircuitMetrics {
             nimp: 58140,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (5218406, 9120204, 61170),
         }
     }
 
@@ -545,7 +545,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (23959035, 23845930, 4840600),
         }
     }
 
@@ -560,7 +560,7 @@ impl CircuitMetrics {
             nimp: 99752,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (8322206, 14806386, 85360),
         }
     }
 
@@ -575,7 +575,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (27956519, 27819485, 5654355),
         }
     }
 
@@ -590,7 +590,7 @@ impl CircuitMetrics {
             nimp: 115928,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (9783988, 17314069, 127995),
         }
     }
 
@@ -605,7 +605,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (24942422, 23803137, 5137811),
         }
     }
 
@@ -620,7 +620,7 @@ impl CircuitMetrics {
             nimp: 80920,
             nsor: 0,
 
-            fanout: (0, 0, 0),
+            fanout: (8722376, 14693413, 124423),
         }
     }
 }

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -257,7 +257,7 @@ impl Gate {
     }
 }
 
-pub struct GateCount {
+pub struct CircuitMetrics {
     pub and: usize,
     pub or: usize,
     pub xor: usize,
@@ -266,9 +266,11 @@ pub struct GateCount {
     pub xnor: usize,
     pub nimp: usize,
     pub nsor: usize,
+
+    pub fanout: usize,
 }
 
-impl Add for GateCount {
+impl Add for CircuitMetrics {
     type Output = Self;
 
     fn add(self, other: Self) -> Self::Output {
@@ -281,11 +283,13 @@ impl Add for GateCount {
             xnor: self.xnor + other.xnor,
             nimp: self.nimp + other.nimp,
             nsor: self.nsor + other.nsor,
+
+            fanout: self.fanout + other.fanout,
         }
     }
 }
 
-impl AddAssign for GateCount {
+impl AddAssign for CircuitMetrics {
     fn add_assign(&mut self, other: Self) {
         self.and = self.and + other.and;
         self.or = self.or + other.or;
@@ -295,10 +299,12 @@ impl AddAssign for GateCount {
         self.xnor = self.xnor + other.xnor;
         self.nimp = self.nimp + other.nimp;
         self.nsor = self.nsor + other.nsor;
+
+        self.fanout = self.fanout + other.fanout;
     }
 }
 
-impl GateCount {
+impl CircuitMetrics {
     pub fn zero() -> Self {
         Self {
             and: 0,
@@ -309,14 +315,16 @@ impl GateCount {
             xnor: 0,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
-    pub fn total_gate_count(&self) -> usize {
+    pub fn total_circuit_metrics(&self) -> usize {
         self.and + self.or + self.xor + self.nand + self.not + self.xnor + self.nimp + self.nsor
     }
 
-    pub fn nonfree_gate_count(&self) -> usize {
+    pub fn nonfree_circuit_metrics(&self) -> usize {
         self.and + self.or + self.nand + self.nimp + self.nsor
     }
 
@@ -330,13 +338,14 @@ impl GateCount {
         println!("nimp: {:?}", self.nimp);
         println!("nsor: {:?}", self.nsor);
         println!();
-        println!("total: {:?}", self.total_gate_count());
-        println!("nonfree: {:?}", self.nonfree_gate_count());
+        println!("total: {:?}", self.total_circuit_metrics());
+        println!("nonfree: {:?}", self.nonfree_circuit_metrics());
+        println!("fanout: {:?}", self.fanout);
     }
 }
 
 // these are here to speed up tests
-impl GateCount {
+impl CircuitMetrics {
     pub fn msm() -> Self {
         Self {
             and: 128808400,
@@ -347,6 +356,8 @@ impl GateCount {
             xnor: 51296850,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -360,6 +371,8 @@ impl GateCount {
             xnor: 89650,
             nimp: 1078400,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -373,6 +386,8 @@ impl GateCount {
             xnor: 4837396,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -386,6 +401,8 @@ impl GateCount {
             xnor: 108020,
             nimp: 80880,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -399,6 +416,8 @@ impl GateCount {
             xnor: 2357575,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -412,6 +431,8 @@ impl GateCount {
             xnor: 53251,
             nimp: 48528,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -425,6 +446,8 @@ impl GateCount {
             xnor: 5912170,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -438,6 +461,8 @@ impl GateCount {
             xnor: 151360,
             nimp: 121320,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -451,6 +476,8 @@ impl GateCount {
             xnor: 13277144,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -464,6 +491,8 @@ impl GateCount {
             xnor: 473862,
             nimp: 240452,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -477,6 +506,8 @@ impl GateCount {
             xnor: 3000110,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -490,6 +521,8 @@ impl GateCount {
             xnor: 26095,
             nimp: 58140,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -503,6 +536,8 @@ impl GateCount {
             xnor: 4769941,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -516,6 +551,8 @@ impl GateCount {
             xnor: 33275,
             nimp: 99752,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -529,6 +566,8 @@ impl GateCount {
             xnor: 5564020,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -542,6 +581,8 @@ impl GateCount {
             xnor: 59246,
             nimp: 115928,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -555,6 +596,8 @@ impl GateCount {
             xnor: 5060584,
             nimp: 0,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 
@@ -568,6 +611,8 @@ impl GateCount {
             xnor: 58734,
             nimp: 80920,
             nsor: 0,
+
+            fanout: 0,
         }
     }
 }

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -267,7 +267,7 @@ pub struct CircuitMetrics {
     pub nimp: usize,
     pub nsor: usize,
 
-    pub fanout: usize,
+    pub fanout: (usize, usize, usize),
 }
 
 impl Add for CircuitMetrics {
@@ -284,7 +284,11 @@ impl Add for CircuitMetrics {
             nimp: self.nimp + other.nimp,
             nsor: self.nsor + other.nsor,
 
-            fanout: self.fanout + other.fanout,
+            fanout: (
+                self.fanout.0 + other.fanout.0,
+                self.fanout.1 + other.fanout.1,
+                self.fanout.2 + other.fanout.2,
+            ),
         }
     }
 }
@@ -300,7 +304,11 @@ impl AddAssign for CircuitMetrics {
         self.nimp = self.nimp + other.nimp;
         self.nsor = self.nsor + other.nsor;
 
-        self.fanout = self.fanout + other.fanout;
+        self.fanout = (
+            self.fanout.0 + other.fanout.0,
+            self.fanout.1 + other.fanout.1,
+            self.fanout.2 + other.fanout.2,
+        );
     }
 }
 
@@ -316,7 +324,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -357,7 +365,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -372,7 +380,7 @@ impl CircuitMetrics {
             nimp: 1078400,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -387,7 +395,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -402,7 +410,7 @@ impl CircuitMetrics {
             nimp: 80880,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -417,7 +425,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -432,7 +440,7 @@ impl CircuitMetrics {
             nimp: 48528,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -447,7 +455,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -462,7 +470,7 @@ impl CircuitMetrics {
             nimp: 121320,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -477,7 +485,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -492,7 +500,7 @@ impl CircuitMetrics {
             nimp: 240452,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -507,7 +515,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -522,7 +530,7 @@ impl CircuitMetrics {
             nimp: 58140,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -537,7 +545,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -552,7 +560,7 @@ impl CircuitMetrics {
             nimp: 99752,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -567,7 +575,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -582,7 +590,7 @@ impl CircuitMetrics {
             nimp: 115928,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -597,7 +605,7 @@ impl CircuitMetrics {
             nimp: 0,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 
@@ -612,7 +620,7 @@ impl CircuitMetrics {
             nimp: 80920,
             nsor: 0,
 
-            fanout: 0,
+            fanout: (0, 0, 0),
         }
     }
 }

--- a/src/core/s.rs
+++ b/src/core/s.rs
@@ -2,7 +2,7 @@ use blake3::hash;
 use rand::{Rng, rng};
 use std::{iter::zip, ops::Add};
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct S(pub [u8; 32]);
 
 impl S {

--- a/src/core/s.rs
+++ b/src/core/s.rs
@@ -2,7 +2,7 @@ use blake3::hash;
 use rand::{Rng, rng};
 use std::{iter::zip, ops::Add};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct S(pub [u8; 32]);
 
 impl S {

--- a/src/core/wire.rs
+++ b/src/core/wire.rs
@@ -2,7 +2,7 @@ use crate::core::s::S;
 use crate::core::utils::{LIMB_LEN, N_LIMBS, convert_between_blake3_and_normal_form};
 use bitvm::{bigint::U256, hash::blake3::blake3_compute_script_with_limb, treepp::*};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Wire {
     pub label0: S,
     pub label1: S,
@@ -50,6 +50,14 @@ impl Wire {
     pub fn get_label(&self) -> S {
         assert!(self.value.is_some());
         self.label.unwrap()
+    }
+
+    pub fn get_label0(&self) -> S {
+        self.label0
+    }
+
+    pub fn get_label1(&self) -> S {
+        self.label1
     }
 
     pub fn set(&mut self, bit: bool) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod bag {
     pub use std::{cell::RefCell, rc::Rc};
     pub type Wirex = Rc<RefCell<Wire>>;
     pub type Wires = Vec<Wirex>;
-    pub use crate::core::gate::GateCount;
+    pub use crate::core::gate::CircuitMetrics;
     pub fn new_wirex() -> Wirex {
         Rc::new(RefCell::new(Wire::new()))
     }


### PR DESCRIPTION
Statistic for fan-out number

- add fan-out information for each wire
- add a switcher to avoid low performance (will take triple time than before)
- add opt-level for dev profile

Some results:
- test_msm_with_constant_bases_evaluate_montgomery
number of fan-out=1 wire: 186431575
number of fan-out=2 wire: 158753800
number of fan-out>2 wire: 610654
- test_fq12_square_montgomery
number of fan-out=1 wire: 7196286
number of fan-out=2 wire: 12381050
number of fan-out>2 wire: 169578
- groth16 verifier
number of fan-out=1 wire: 5420934112
number of fan-out=2 wire: 9122628805
number of fan-out>2 wire: 96960072
