### PR TITLE
refactor: make gate type enum, not string

### DIFF
--- a/src/core/bristol.rs
+++ b/src/core/bristol.rs
@@ -1,4 +1,5 @@
 use crate::bag::*;
+use crate::core::gate::GateType;
 use std::fs;
 
 pub fn parser(filename: &str) -> (Circuit, Vec<Wires>, Vec<Wires>) {
@@ -45,7 +46,18 @@ pub fn parser(filename: &str) -> (Circuit, Vec<Wires>, Vec<Wires>) {
         for _ in 0..number_of_outputs {
             output_wires.push(words.next().unwrap().parse().unwrap());
         }
-        let gate_type = words.next().unwrap().to_lowercase();
+        let gate_type_str = words.next().unwrap().to_lowercase();
+        let gate_type = match gate_type_str.as_str() {
+            "and" => GateType::And,
+            "or" => GateType::Or,
+            "xor" => GateType::Xor,
+            "nand" => GateType::Nand,
+            "inv" | "not" => GateType::Not,
+            "xnor" => GateType::Xnor,
+            "nimp" => GateType::Nimp,
+            "nsor" => GateType::Nsor,
+            _ => panic!("Unknown gate type: {}", gate_type_str),
+        };
         let gate = Gate::new(
             wires[input_wires[0]].clone(),
             if number_of_inputs == 1 {

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -1,4 +1,7 @@
-use crate::{bag::*, core::gate::GateCount};
+use crate::{
+    bag::*,
+    core::gate::{GateCount, GateType},
+};
 
 pub struct Circuit(pub Wires, pub Vec<Gate>);
 
@@ -46,16 +49,15 @@ impl Circuit {
         let mut nimp = 0;
         let mut nsor = 0;
         for gate in self.1.clone() {
-            match gate.name.as_str() {
-                "and" => and += 1,
-                "or" => or += 1,
-                "xor" => xor += 1,
-                "nand" => nand += 1,
-                "inv" | "not" => not += 1,
-                "xnor" => xnor += 1,
-                "nimp" => nimp += 1,
-                "nsor" => nsor += 1,
-                _ => panic!("this gate type is not allowed"),
+            match gate.gate_type {
+                GateType::And => and += 1,
+                GateType::Or => or += 1,
+                GateType::Xor => xor += 1,
+                GateType::Nand => nand += 1,
+                GateType::Not => not += 1,
+                GateType::Xnor => xnor += 1,
+                GateType::Nimp => nimp += 1,
+                GateType::Nsor => nsor += 1,
             }
         }
         GateCount {


### PR DESCRIPTION
A trivial refactoring, but accelerated the `eval` quite a bit.

I did [benchmark](https://github.com/babylonlabs-io/garbled-snark-verifier/blob/dev/benches/groth16_verifier.rs), it showed this increase: 27%, from 63.3s to 45.8s

```terminal
time:   [45.733 s 45.799 s 45.861 s]
change: [-28.001% -27.760% -27.471%] (p = 0.00 < 0.05)
Performance has improved.
```