### PR TITLE
refactor: unclone cycles

### DIFF
--- a/src/circuits/basic.rs
+++ b/src/circuits/basic.rs
@@ -281,7 +281,7 @@ mod tests {
         let a: Wires = (0..n).map(|_| new_wirex()).collect();
         let s: Wires = (0..w).map(|_| new_wirex()).collect();
 
-        for wire in a.clone() {
+        for wire in a.iter() {
             wire.borrow_mut().set(rng().random());
         }
 

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -99,9 +99,9 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         add_generic(a, b, N_BITS)
     }
 
-    pub fn add_constant(a: Wires, b: BigUint) -> Circuit {
+    pub fn add_constant(a: Wires, b: &BigUint) -> Circuit {
         assert_eq!(a.len(), N_BITS);
-        assert_ne!(b, BigUint::ZERO);
+        assert_ne!(b, &BigUint::ZERO);
         let mut circuit = Circuit::empty();
 
         let b_bits = bits_from_biguint(b);
@@ -155,9 +155,9 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         circuit
     }
 
-    pub fn add_constant_without_carry(a: Wires, b: BigUint) -> Circuit {
+    pub fn add_constant_without_carry(a: Wires, b: &BigUint) -> Circuit {
         assert_eq!(a.len(), N_BITS);
-        assert_ne!(b, BigUint::ZERO);
+        assert_ne!(b, &BigUint::ZERO);
         let mut circuit = Circuit::empty();
 
         let b_bits = bits_from_biguint(b);
@@ -316,8 +316,8 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
         let circuit = U254::add(
-            U254::wires_set_from_number(a.clone()),
-            U254::wires_set_from_number(b.clone()),
+            U254::wires_set_from_number(&a),
+            U254::wires_set_from_number(&b),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -331,7 +331,7 @@ mod tests {
     fn test_add_constant() {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
-        let circuit = U254::add_constant(U254::wires_set_from_number(a.clone()), b.clone());
+        let circuit = U254::add_constant(U254::wires_set_from_number(&a), &b);
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -345,8 +345,8 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
         let circuit = U254::add_without_carry(
-            U254::wires_set_from_number(a.clone()),
-            U254::wires_set_from_number(b.clone()),
+            U254::wires_set_from_number(&a),
+            U254::wires_set_from_number(&b),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -364,8 +364,8 @@ mod tests {
             (a, b) = (b, a);
         }
         let circuit = U254::sub(
-            U254::wires_set_from_number(a.clone()),
-            U254::wires_set_from_number(b.clone()),
+            U254::wires_set_from_number(&a),
+            U254::wires_set_from_number(&b),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -383,8 +383,8 @@ mod tests {
             (a, b) = (b, a);
         }
         let circuit = U254::sub_without_borrow(
-            U254::wires_set_from_number(a.clone()),
-            U254::wires_set_from_number(b.clone()),
+            U254::wires_set_from_number(&a),
+            U254::wires_set_from_number(&b),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn test_double() {
         let a = random_biguint_n_bits(254);
-        let circuit = U254::double(U254::wires_set_from_number(a.clone()));
+        let circuit = U254::double(U254::wires_set_from_number(&a));
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -409,7 +409,7 @@ mod tests {
     #[test]
     fn test_double_without_overflow() {
         let a = random_biguint_n_bits(254);
-        let circuit = U254::double_without_overflow(U254::wires_set_from_number(a.clone()));
+        let circuit = U254::double_without_overflow(U254::wires_set_from_number(&a));
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -421,7 +421,7 @@ mod tests {
     #[test]
     fn test_half() {
         let a = random_biguint_n_bits(254);
-        let circuit = U254::half(U254::wires_set_from_number(a.clone()));
+        let circuit = U254::half(U254::wires_set_from_number(&a));
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -434,7 +434,7 @@ mod tests {
     #[test]
     fn test_odd_part() {
         let a = random_biguint_n_bits(254);
-        let circuit = U254::odd_part(U254::wires_set_from_number(a.clone()));
+        let circuit = U254::odd_part(U254::wires_set_from_number(&a));
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -450,8 +450,8 @@ mod tests {
             let a = random_biguint_n_bits(254);
             let b = random_biguint_n_bits(254);
             let mut circuit = U254::optimized_sub(
-                U254::wires_set_from_number(a.clone()),
-                U254::wires_set_from_number(b.clone()),
+                U254::wires_set_from_number(&a),
+                U254::wires_set_from_number(&b),
                 true,
             );
             circuit.gate_counts().print();

--- a/src/circuits/bigint/cmp.rs
+++ b/src/circuits/bigint/cmp.rs
@@ -27,12 +27,12 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         for i in 0..N_BITS {
             circuit.add(Gate::xor(a[i].clone(), b[i].clone(), c[i].clone()));
         }
-        let result = circuit.extend(Self::equal_constant(c, BigUint::ZERO));
+        let result = circuit.extend(Self::equal_constant(c, &BigUint::ZERO));
         circuit.add_wires(result);
         circuit
     }
 
-    pub fn equal_constant(a: Wires, b: BigUint) -> Circuit {
+    pub fn equal_constant(a: Wires, b: &BigUint) -> Circuit {
         assert_eq!(a.len(), Self::N_BITS);
         let mut circuit = Circuit::empty();
 
@@ -79,7 +79,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         circuit
     }
 
-    pub fn less_than_constant(a: Wires, b: BigUint) -> Circuit {
+    pub fn less_than_constant(a: Wires, b: &BigUint) -> Circuit {
         assert_eq!(a.len(), N_BITS);
         let mut circuit = Circuit::empty();
 
@@ -110,7 +110,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         self_or_zero_generic(a, s, N_BITS)
     }
 
-    pub fn self_or_zero_constant(a: BigUint, s: Wirex) -> Circuit {
+    pub fn self_or_zero_constant(a: &BigUint, s: Wirex) -> Circuit {
         let mut bit_wires = vec![];
         let mut bits = bits_from_biguint(a);
         bits.resize(Self::N_BITS, false);
@@ -124,7 +124,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
     pub fn multiplexer(a: Vec<Wires>, s: Wires, w: usize) -> Circuit {
         let n = 2_usize.pow(w.try_into().unwrap());
         assert_eq!(a.len(), n);
-        for x in a.clone() {
+        for x in a.iter() {
             assert_eq!(x.len(), N_BITS);
         }
         assert_eq!(s.len(), w);
@@ -156,8 +156,8 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
         let circuit = U254::equal(
-            U254::wires_set_from_number(a.clone()),
-            U254::wires_set_from_number(b.clone()),
+            U254::wires_set_from_number(&a),
+            U254::wires_set_from_number(&b),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -167,8 +167,8 @@ mod tests {
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::equal(
-            U254::wires_set_from_number(a.clone()),
-            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(&a),
+            U254::wires_set_from_number(&a),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -177,7 +177,7 @@ mod tests {
         assert!(circuit.0[0].borrow().get_value());
 
         let a = random_biguint_n_bits(254);
-        let circuit = U254::equal_constant(U254::wires_set_from_number(a.clone()), b.clone());
+        let circuit = U254::equal_constant(U254::wires_set_from_number(&a), &b);
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -190,8 +190,8 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
-            U254::wires_set_from_number(a.clone()),
-            U254::wires_set_from_number(b.clone()),
+            U254::wires_set_from_number(&a),
+            U254::wires_set_from_number(&b),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -201,8 +201,8 @@ mod tests {
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
-            U254::wires_set_from_number(a.clone()),
-            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(&a),
+            U254::wires_set_from_number(&a),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -212,8 +212,8 @@ mod tests {
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
-            U254::wires_set_from_number(a.clone() + BigUint::from_str("1").unwrap()),
-            U254::wires_set_from_number(a.clone()),
+            U254::wires_set_from_number(&(&a + BigUint::from_str("1").unwrap())),
+            U254::wires_set_from_number(&a),
         );
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -226,7 +226,7 @@ mod tests {
     fn test_less_than_constant() {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
-        let circuit = U254::less_than_constant(U254::wires_set_from_number(a.clone()), b.clone());
+        let circuit = U254::less_than_constant(U254::wires_set_from_number(&a), &b);
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -241,8 +241,8 @@ mod tests {
         let s = new_wirex();
         s.borrow_mut().set(true);
         let circuit = U254::select(
-            U254::wires_set_from_number(a.clone()),
-            U254::wires_set_from_number(b.clone()),
+            U254::wires_set_from_number(&a),
+            U254::wires_set_from_number(&b),
             s,
         );
         circuit.gate_counts().print();
@@ -259,7 +259,7 @@ mod tests {
 
         let s = new_wirex();
         s.borrow_mut().set(true);
-        let circuit = U254::self_or_zero(U254::wires_set_from_number(a.clone()), s);
+        let circuit = U254::self_or_zero(U254::wires_set_from_number(&a), s);
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -269,7 +269,7 @@ mod tests {
 
         let s = new_wirex();
         s.borrow_mut().set(false);
-        let circuit = U254::self_or_zero(U254::wires_set_from_number(a.clone()), s);
+        let circuit = U254::self_or_zero(U254::wires_set_from_number(&a), s);
         for mut gate in circuit.1 {
             gate.evaluate();
         }
@@ -285,7 +285,7 @@ mod tests {
         let s: Wires = (0..w).map(|_| new_wirex()).collect();
 
         let mut a_wires = Vec::new();
-        for e in a.clone() {
+        for e in a.iter() {
             a_wires.push(U254::wires_set_from_number(e));
         }
 

--- a/src/circuits/bigint/mod.rs
+++ b/src/circuits/bigint/mod.rs
@@ -16,7 +16,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
     pub fn wires() -> Wires {
         n_wires(N_BITS)
     }
-    pub fn wires_set_from_number(u: BigUint) -> Wires {
+    pub fn wires_set_from_number(u: &BigUint) -> Wires {
         bits_from_biguint(u)[0..N_BITS]
             .iter()
             .map(|bit| {

--- a/src/circuits/bigint/mul.rs
+++ b/src/circuits/bigint/mul.rs
@@ -157,7 +157,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
     pub fn mul_by_constant(a_wires: Wires, c: BigUint) -> Circuit {
         assert_eq!(a_wires.len(), N_BITS);
-        let mut c_bits = bits_from_biguint(c);
+        let mut c_bits = bits_from_biguint(&c);
         c_bits.truncate(N_BITS);
 
         let mut circuit = Circuit::empty();
@@ -208,7 +208,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
     pub fn mul_by_constant_modulo_power_two(a_wires: Wires, c: BigUint, power: usize) -> Circuit {
         assert_eq!(a_wires.len(), N_BITS);
         assert!(power < 2 * N_BITS);
-        let mut c_bits = bits_from_biguint(c);
+        let mut c_bits = bits_from_biguint(&c);
         c_bits.truncate(N_BITS);
 
         let mut circuit = Circuit::empty();
@@ -265,10 +265,10 @@ mod tests {
             let a = random_biguint_n_bits(254);
             let b = random_biguint_n_bits(254);
             let circuit = U254::mul(
-                U254::wires_set_from_number(a.clone()),
-                U254::wires_set_from_number(b.clone()),
+                U254::wires_set_from_number(&a),
+                U254::wires_set_from_number(&b),
             );
-            let c = a * b;
+            let c = &a * &b;
             circuit.gate_counts().print();
 
             for mut gate in circuit.1 {
@@ -292,10 +292,10 @@ mod tests {
             let a = random_biguint_n_bits(254);
             let b = random_biguint_n_bits(254);
             let circuit = U254::mul_karatsuba(
-                U254::wires_set_from_number(a.clone()),
-                U254::wires_set_from_number(b.clone()),
+                U254::wires_set_from_number(&a),
+                U254::wires_set_from_number(&b),
             );
-            let c = a * b;
+            let c = &a * &b;
             circuit.gate_counts().print();
 
             for mut gate in circuit.1 {
@@ -321,11 +321,9 @@ mod tests {
             let b = random_biguint_n_bits(S);
             pub type T = BigIntImpl<S>;
 
-            let circuit = T::mul_karatsuba(
-                T::wires_set_from_number(a.clone()),
-                T::wires_set_from_number(b.clone()),
-            );
-            let c = a * b;
+            let circuit =
+                T::mul_karatsuba(T::wires_set_from_number(&a), T::wires_set_from_number(&b));
+            let c = &a * &b;
             circuit.gate_counts().print();
 
             for mut gate in circuit.1 {
@@ -348,8 +346,8 @@ mod tests {
         for _ in 0..10 {
             let a = random_biguint_n_bits(254);
             let b = random_biguint_n_bits(254);
-            let circuit = U254::mul_by_constant(U254::wires_set_from_number(a.clone()), b.clone());
-            let c = a * b;
+            let circuit = U254::mul_by_constant(U254::wires_set_from_number(&a), b.clone());
+            let c = &a * &b;
             circuit.gate_counts().print();
 
             for mut gate in circuit.1 {
@@ -374,11 +372,11 @@ mod tests {
             let a = random_biguint_n_bits(254);
             let b = random_biguint_n_bits(254);
             let circuit = U254::mul_by_constant_modulo_power_two(
-                U254::wires_set_from_number(a.clone()),
+                U254::wires_set_from_number(&a),
                 b.clone(),
                 power,
             );
-            let c = a * b % BigUint::from_str("2").unwrap().pow(power as u32);
+            let c = &a * &b % BigUint::from_str("2").unwrap().pow(power as u32);
             circuit.gate_counts().print();
 
             for mut gate in circuit.1 {

--- a/src/circuits/bigint/utils.rs
+++ b/src/circuits/bigint/utils.rs
@@ -22,7 +22,7 @@ pub fn random_biguint_n_bits(n_bits: usize) -> BigUint {
         % BigUint::from_str("2").unwrap().pow(n_bits as u32)
 }
 
-pub fn bits_from_biguint(u: BigUint) -> Vec<bool> {
+pub fn bits_from_biguint(u: &BigUint) -> Vec<bool> {
     let mut bytes = u.to_bytes_le();
     bytes.extend(vec![0_u8; 32 - bytes.len()]);
     let mut bits = Vec::new();
@@ -89,7 +89,7 @@ pub mod tests {
     fn test_random_biguint() {
         let u = random_biguint();
         println!("u: {:?}", u);
-        let b = bits_from_biguint(u.clone());
+        let b = bits_from_biguint(&u);
         let v = biguint_from_bits(b);
         println!("v: {:?}", v);
         assert_eq!(u, v);
@@ -99,7 +99,7 @@ pub mod tests {
     fn test_neg_pos_decomposition() {
         for _ in 0..10 {
             let u = random_biguint();
-            let b = bits_from_biguint(u.clone());
+            let b = bits_from_biguint(&u);
             let d = change_to_neg_pos_decomposition(b);
             let len = d.len();
             let mut res = BigUint::ZERO;

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -35,7 +35,7 @@ pub trait Fp254Impl {
     }
 
     fn modulus_as_bits() -> Vec<bool> {
-        bits_from_biguint(Self::modulus_as_biguint())
+        bits_from_biguint(&Self::modulus_as_biguint())
     }
 
     fn not_modulus_as_biguint() -> BigUint {
@@ -47,7 +47,7 @@ pub trait Fp254Impl {
     }
 
     fn not_modulus_as_bits() -> Vec<bool> {
-        bits_from_biguint(Self::not_modulus_as_biguint())
+        bits_from_biguint(&Self::not_modulus_as_biguint())
     }
 
     fn half_modulus() -> BigUint;
@@ -69,11 +69,11 @@ pub trait Fp254Impl {
     }
 
     fn equal_constant(a: Wires, b: ark_bn254::Fq) -> Circuit {
-        U254::equal_constant(a, BigUint::from(b))
+        U254::equal_constant(a, &BigUint::from(b))
     }
 
     fn equal_zero(a: Wires) -> Circuit {
-        U254::equal_constant(a, BigUint::ZERO)
+        U254::equal_constant(a, &BigUint::ZERO)
     }
 
     fn add(a: Wires, b: Wires) -> Circuit {
@@ -84,13 +84,13 @@ pub trait Fp254Impl {
         let mut wires_1 = circuit.extend(U254::add(a, b));
         let u = wires_1.pop().unwrap();
         let c = Self::not_modulus_as_biguint();
-        let mut wires_2 = circuit.extend(U254::add_constant(wires_1.clone(), c));
+        let mut wires_2 = circuit.extend(U254::add_constant(wires_1.clone(), &c));
         wires_2.pop();
         let not_u = new_wirex();
         circuit.add(Gate::not(u.clone(), not_u.clone()));
         let v = circuit.extend(U254::less_than_constant(
             wires_1.clone(),
-            Self::modulus_as_biguint(),
+            &Self::modulus_as_biguint(),
         ))[0]
             .clone();
         let s = new_wirex();
@@ -109,16 +109,16 @@ pub trait Fp254Impl {
             return circuit;
         }
 
-        let mut wires_1 = circuit.extend(U254::add_constant(a.clone(), BigUint::from(b)));
+        let mut wires_1 = circuit.extend(U254::add_constant(a.clone(), &BigUint::from(b)));
         let u = wires_1.pop().unwrap();
         let c = Self::not_modulus_as_biguint();
-        let mut wires_2 = circuit.extend(U254::add_constant(wires_1.clone(), c));
+        let mut wires_2 = circuit.extend(U254::add_constant(wires_1.clone(), &c));
         wires_2.pop();
         let not_u = new_wirex();
         circuit.add(Gate::not(u.clone(), not_u.clone()));
         let v = circuit.extend(U254::less_than_constant(
             wires_1.clone(),
-            Self::modulus_as_biguint(),
+            &Self::modulus_as_biguint(),
         ))[0]
             .clone();
         let s = new_wirex();
@@ -170,13 +170,13 @@ pub trait Fp254Impl {
         let mut shifted_wires = vec![shift_wire];
         shifted_wires.extend(aa);
         let c = Self::not_modulus_as_biguint();
-        let mut wires_2 = circuit.extend(U254::add_constant(shifted_wires.clone(), c));
+        let mut wires_2 = circuit.extend(U254::add_constant(shifted_wires.clone(), &c));
         wires_2.pop();
         let not_u = new_wirex();
         circuit.add(Gate::not(u.clone(), not_u.clone()));
         let v = circuit.extend(U254::less_than_constant(
             shifted_wires.clone(),
-            Self::modulus_as_biguint(),
+            &Self::modulus_as_biguint(),
         ))[0]
             .clone();
         let s = new_wirex();
@@ -194,7 +194,7 @@ pub trait Fp254Impl {
         let wires_1 = circuit.extend(U254::half(a.clone()));
         let wires_2 = circuit.extend(U254::add_constant_without_carry(
             wires_1.clone(),
-            Self::half_modulus(),
+            &Self::half_modulus(),
         ));
         let result = circuit.extend(U254::select(wires_2, wires_1, selector));
         circuit.add_wires(result);
@@ -241,7 +241,7 @@ pub trait Fp254Impl {
             circuit.extend(U254::mul_by_constant(q, Self::modulus_as_biguint()))[254..508].to_vec();
         let bound_check = circuit.extend(U254::greater_than(sub.clone(), x_high.clone()));
         let subtract_if_too_much = circuit.extend(U254::self_or_zero_constant(
-            Self::modulus_as_biguint(),
+            &Self::modulus_as_biguint(),
             bound_check[0].clone(),
         ));
         let new_sub = circuit.extend(U254::optimized_sub(sub, subtract_if_too_much, false));
@@ -383,7 +383,7 @@ pub trait Fp254Impl {
             let s1 = circuit.extend(U254::double_without_overflow(s.clone()));
             let k1 = circuit.extend(U254::add_constant_without_carry(
                 k.clone(),
-                BigUint::from_str("1").unwrap(),
+                &BigUint::from_str("1").unwrap(),
             ));
 
             // part2
@@ -393,7 +393,7 @@ pub trait Fp254Impl {
             let s2 = s.clone();
             let k2 = circuit.extend(U254::add_constant_without_carry(
                 k.clone(),
-                BigUint::from_str("1").unwrap(),
+                &BigUint::from_str("1").unwrap(),
             ));
 
             // part3
@@ -403,7 +403,7 @@ pub trait Fp254Impl {
             let s3 = circuit.extend(U254::double_without_overflow(s.clone()));
             let k3 = circuit.extend(U254::add_constant_without_carry(
                 k.clone(),
-                BigUint::from_str("1").unwrap(),
+                &BigUint::from_str("1").unwrap(),
             ));
 
             // part4
@@ -413,7 +413,7 @@ pub trait Fp254Impl {
             let s4 = circuit.extend(U254::add_without_carry(r.clone(), s.clone()));
             let k4 = circuit.extend(U254::add_constant_without_carry(
                 k.clone(),
-                BigUint::from_str("1").unwrap(),
+                &BigUint::from_str("1").unwrap(),
             ));
 
             // calculate new u
@@ -470,7 +470,7 @@ pub trait Fp254Impl {
 
             let v_equals_one = circuit.extend(U254::equal_constant(
                 v.clone(),
-                BigUint::from_str("1").unwrap(),
+                &BigUint::from_str("1").unwrap(),
             ))[0]
                 .clone();
             u = circuit.extend(U254::select(u, new_u, v_equals_one.clone()));
@@ -563,7 +563,7 @@ pub trait Fp254Impl {
         // residue for r2
         let result_plus_one_third = circuit.extend(U254::add_constant_without_carry(
             result.clone(),
-            Self::one_third_modulus(),
+            &Self::one_third_modulus(),
         ));
         result = circuit.extend(U254::select(
             result_plus_one_third,
@@ -573,7 +573,7 @@ pub trait Fp254Impl {
         // residue for r1
         let result_plus_two_third = circuit.extend(U254::add_constant_without_carry(
             result.clone(),
-            Self::two_third_modulus(),
+            &Self::two_third_modulus(),
         ));
         result = circuit.extend(U254::select(
             result_plus_two_third,

--- a/src/circuits/bn254/g1.rs
+++ b/src/circuits/bn254/g1.rs
@@ -324,7 +324,7 @@ impl G1Projective {
     pub fn multiplexer(a: Vec<Wires>, s: Wires, w: usize) -> Circuit {
         let n = 2_usize.pow(w.try_into().unwrap());
         assert_eq!(a.len(), n);
-        for x in a.clone() {
+        for x in a.iter() {
             assert_eq!(x.len(), Self::N_BITS);
         }
         assert_eq!(s.len(), w);
@@ -919,8 +919,8 @@ mod tests {
         let s: Wires = (0..w).map(|_| new_wirex()).collect();
 
         let mut a_wires = Vec::new();
-        for e in a.clone() {
-            a_wires.push(G1Projective::wires_set(e));
+        for e in a.iter() {
+            a_wires.push(G1Projective::wires_set(*e));
         }
 
         let mut u = 0;
@@ -951,8 +951,8 @@ mod tests {
         let s: Wires = (0..w).map(|_| new_wirex()).collect();
 
         let mut a_wires = Vec::new();
-        for e in a.clone() {
-            a_wires.push(G1Projective::wires_set(e));
+        for e in a.iter() {
+            a_wires.push(G1Projective::wires_set(*e));
         }
 
         let mut u = 0;

--- a/src/circuits/bn254/pairing.rs
+++ b/src/circuits/bn254/pairing.rs
@@ -1085,7 +1085,7 @@ pub fn multi_miller_loop(
     let mut u = Vec::new();
     for i in 0..qells[0].len() {
         let mut x = Vec::new();
-        for qell in qells.clone() {
+        for qell in qells.iter() {
             x.push(qell[i]);
         }
         u.push(x);
@@ -1135,7 +1135,7 @@ pub fn multi_miller_loop_evaluate_fast(ps: Vec<Wires>, qs: Vec<Wires>) -> (Wires
     let mut u = Vec::new();
     for i in 0..qells[0].len() {
         let mut x = Vec::new();
-        for qell in qells.clone() {
+        for qell in qells.iter() {
             x.push(qell[i].clone());
         }
         u.push(x);
@@ -1245,7 +1245,7 @@ pub fn multi_miller_loop_evaluate_montgomery_fast(
     let mut u = Vec::new();
     for i in 0..qells[0].len() {
         let mut x = Vec::new();
-        for qell in qells.clone() {
+        for qell in qells.iter() {
             x.push(qell[i].clone());
         }
         u.push(x);

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -40,36 +40,22 @@ impl Circuit {
     }
 
     pub fn gate_counts(&self) -> GateCount {
-        let mut and = 0;
-        let mut or = 0;
-        let mut xor = 0;
-        let mut nand = 0;
-        let mut not = 0;
-        let mut xnor = 0;
-        let mut nimp = 0;
-        let mut nsor = 0;
-        for gate in self.1.clone() {
+        let mut gc = GateCount::default();
+
+        for gate in self.1.iter() {
             match gate.gate_type {
-                GateType::And => and += 1,
-                GateType::Or => or += 1,
-                GateType::Xor => xor += 1,
-                GateType::Nand => nand += 1,
-                GateType::Not => not += 1,
-                GateType::Xnor => xnor += 1,
-                GateType::Nimp => nimp += 1,
-                GateType::Nsor => nsor += 1,
+                GateType::And => gc.and += 1,
+                GateType::Or => gc.or += 1,
+                GateType::Xor => gc.xor += 1,
+                GateType::Nand => gc.nand += 1,
+                GateType::Not => gc.not += 1,
+                GateType::Xnor => gc.xnor += 1,
+                GateType::Nimp => gc.nimp += 1,
+                GateType::Nsor => gc.nsor += 1,
             }
         }
-        GateCount {
-            and,
-            or,
-            xor,
-            nand,
-            not,
-            xnor,
-            nimp,
-            nsor,
-        }
+
+        gc
     }
 }
 

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -3,9 +3,10 @@ use crate::core::utils::{LIMB_LEN, N_LIMBS, bit_to_usize, convert_between_blake3
 use bitvm::{bigint::U256, hash::blake3::blake3_compute_script_with_limb, treepp::*};
 use std::ops::{Add, AddAssign};
 
-#[derive(Clone, Debug, PartialEq)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GateType {
-    And,
+    And = 0,
     Or,
     Xor,
     Nand,
@@ -265,6 +266,7 @@ impl Gate {
     }
 }
 
+#[derive(Default)]
 pub struct GateCount {
     pub and: usize,
     pub or: usize,


### PR DESCRIPTION
Another trivial refactoring

There is a `for _ in something.clone()` patter within the code and some such clones are called millionrs of times. Remove it and get an 6.6% performance gain

```console
time:   [42.805 s 42.876 s 42.931 s]                  
change: [-6.8468% -6.6651% -6.4971%] (p = 0.00 < 0.05)
Performance has improved.                             
```

I also removed clones of `BitUint` structu, since it is not necessary to clone values for conversion to bits
