### PR TITLE
Subtraction AND Optimization and All Gate Types 

### DIFF
--- a/src/circuits/basic.rs
+++ b/src/circuits/basic.rs
@@ -27,48 +27,35 @@ pub fn full_adder(a: Wirex, b: Wirex, c: Wirex) -> Circuit {
 pub fn half_subtracter(a: Wirex, b: Wirex) -> Circuit {
     let result = new_wirex();
     let borrow = new_wirex();
-    let not_a = new_wirex();
-    let gate_not_a = Gate::not(a.clone(), not_a.clone());
     let gate_result = Gate::xor(a.clone(), b.clone(), result.clone());
-    let gate_borrow = Gate::and(not_a.clone(), b.clone(), borrow.clone());
-    Circuit::new(
-        vec![result, borrow],
-        vec![gate_not_a, gate_result, gate_borrow],
-    )
+    let gate_borrow = Gate::and_variant(a.clone(), b.clone(), borrow.clone(), [1, 0, 0]);
+    Circuit::new(vec![result, borrow], vec![gate_result, gate_borrow])
 }
 
 pub fn full_subtracter(a: Wirex, b: Wirex, c: Wirex) -> Circuit {
-    let d = new_wirex();
-    let e = new_wirex();
-    let f = new_wirex();
-    let g = new_wirex();
-    let h = new_wirex();
+    let bxa = new_wirex();
+    let bxc = new_wirex();
     let result = new_wirex();
-    let borrow = new_wirex();
+    let t = new_wirex();
+    let carry = new_wirex();
 
-    let gate_1 = Gate::xor(a.clone(), b.clone(), d.clone());
-    let gate_2 = Gate::xor(c.clone(), d.clone(), result.clone());
-    let gate_3 = Gate::not(d.clone(), e.clone());
-    let gate_4 = Gate::and(c.clone(), e.clone(), f.clone());
-    let gate_5 = Gate::not(a.clone(), g.clone());
-    let gate_6 = Gate::and(b.clone(), g.clone(), h.clone());
-    let gate_7 = Gate::xor(f.clone(), h.clone(), borrow.clone());
-    Circuit::new(
-        vec![result, borrow],
-        vec![gate_1, gate_2, gate_3, gate_4, gate_5, gate_6, gate_7],
-    )
+    let g1 = Gate::xor(a.clone(), b.clone(), bxa.clone());
+    let g2 = Gate::xor(b.clone(), c.clone(), bxc.clone());
+    let g3 = Gate::xor(bxa.clone().clone(), c.clone(), result.clone());
+    let g4 = Gate::and(bxa.clone(), bxc.clone(), t.clone());
+    let g5 = Gate::xor(c.clone(), t.clone(), carry.clone());
+
+    Circuit::new(vec![result, carry], vec![g1, g2, g3, g4, g5])
 }
 
 pub fn selector(a: Wirex, b: Wirex, c: Wirex) -> Circuit {
     let d = new_wirex();
-    let e = new_wirex();
     let f = new_wirex();
     let g = new_wirex();
-    let gate_1 = Gate::not(c.clone(), e.clone());
-    let gate_2 = Gate::nand(a.clone(), c.clone(), d.clone());
-    let gate_3 = Gate::nand(e.clone(), b.clone(), f.clone());
-    let gate_4 = Gate::nand(d.clone(), f.clone(), g.clone());
-    Circuit::new(vec![g], vec![gate_1, gate_2, gate_3, gate_4])
+    let gate_1 = Gate::nand(a.clone(), c.clone(), d.clone());
+    let gate_2 = Gate::and_variant(c.clone(), b.clone(), f.clone(), [1, 0, 1]);
+    let gate_3 = Gate::nand(d.clone(), f.clone(), g.clone());
+    Circuit::new(vec![g], vec![gate_1, gate_2, gate_3])
 }
 
 pub fn multiplexer(a: Wires, s: Wires, w: usize) -> Circuit {

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -24,74 +24,69 @@ pub fn add_generic(a: Wires, b: Wires, len: usize) -> Circuit {
     circuit
 }
 
-pub fn optimized_sub_generic(
-    a_wires: Wires,
-    b_wires: Wires,
-    check_bound: bool,
-    len: usize,
-) -> Circuit {
-    assert_eq!(a_wires.len(), len);
-    assert_eq!(b_wires.len(), len);
-
+pub fn add_constant_generic(a: Wires, b: &BigUint, len: usize) -> Circuit {
+    assert_eq!(a.len(), len);
+    assert_ne!(b, &BigUint::ZERO);
     let mut circuit = Circuit::empty();
 
-    let mut want: Rc<RefCell<Wire>> = new_wirex();
+    let b_bits = bits_from_biguint(b);
+
+    let mut first_one = 0;
+    while !b_bits[first_one] {
+        first_one += 1;
+    }
+
+    let mut carry = new_wirex();
     for i in 0..len {
-        circuit.add_wire(new_wirex());
-        if i > 0 {
-            let subtract_bit = new_wirex();
-            circuit.add(Gate::xor(
-                want.clone(),
-                b_wires[i].clone(),
-                subtract_bit.clone(),
-            ));
-            circuit.add(Gate::xor(
-                subtract_bit.clone(),
-                a_wires[i].clone(),
-                circuit.0[i].clone(),
-            ));
-            let new_want_or0 = new_wirex();
-            let new_want_or1 = new_wirex();
-            let new_want = new_wirex();
-            circuit.add(Gate::nimp(
-                subtract_bit.clone(),
-                a_wires[i].clone(),
-                new_want_or0.clone(),
-            ));
-            circuit.add(Gate::and(
-                want.clone(),
-                b_wires[i].clone(),
-                new_want_or1.clone(),
-            ));
-            circuit.add(Gate::xor(
-                new_want_or0.clone(),
-                new_want_or1.clone(),
-                new_want.clone(),
-            ));
-            want = new_want;
+        if i < first_one {
+            circuit.add_wire(a[i].clone());
+        } else if i == first_one {
+            let wire = new_wirex();
+            circuit.add(Gate::not(a[i].clone(), wire.clone()));
+            circuit.add_wire(wire);
+            carry = a[i].clone();
+        } else if b_bits[i] {
+            let wire_1 = new_wirex();
+            let wire_2 = new_wirex();
+            circuit.add(Gate::xnor(a[i].clone(), carry.clone(), wire_1.clone()));
+            circuit.add(Gate::or(a[i].clone(), carry.clone(), wire_2.clone()));
+            circuit.add_wire(wire_1);
+            carry = wire_2;
         } else {
-            circuit.add(Gate::xor(
-                b_wires[i].clone(),
-                a_wires[i].clone(),
-                circuit.0[i].clone(),
-            ));
-            let new_want: Rc<RefCell<Wire>> = new_wirex();
-            circuit.add(Gate::nimp(
-                b_wires[i].clone(),
-                a_wires[i].clone(),
-                new_want.clone(),
-            ));
-            want = new_want;
+            let wire_1 = new_wirex();
+            let wire_2 = new_wirex();
+            circuit.add(Gate::xor(a[i].clone(), carry.clone(), wire_1.clone()));
+            circuit.add(Gate::and(a[i].clone(), carry.clone(), wire_2.clone()));
+            circuit.add_wire(wire_1);
+            carry = wire_2;
         }
     }
-
-    if check_bound {
-        let bound_check_wire = new_wirex();
-        circuit.add(Gate::not(want.clone(), bound_check_wire.clone()));
-        circuit.add_wire(bound_check_wire);
-    }
-
+    circuit.add_wire(carry);
     circuit
+}
+
+pub fn sub_generic(a: Wires, b: Wires, len: usize) -> Circuit {
+    assert_eq!(a.len(), len);
+    assert_eq!(b.len(), len);
+
+    let mut circuit = Circuit::empty();
+    let wires = circuit.extend(half_subtracter(a[0].clone(), b[0].clone()));
+    circuit.add_wire(wires[0].clone());
+    let mut borrow = wires[1].clone();
+    for i in 1..len {
+        let wires: Vec<Rc<RefCell<Wire>>> =
+            circuit.extend(full_subtracter(a[i].clone(), b[i].clone(), borrow));
+        circuit.add_wire(wires[0].clone());
+        borrow = wires[1].clone();
+    }
+    circuit.add_wire(borrow);
+    circuit
+}
+
+pub fn sub_generic_without_borrow(a: Wires, b: Wires, len: usize) -> Circuit {
+    let mut c = sub_generic(a, b, len);
+    c.0.pop();
+    c
 }
 
 impl<const N_BITS: usize> BigIntImpl<N_BITS> {
@@ -99,119 +94,30 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         add_generic(a, b, N_BITS)
     }
 
-    pub fn add_constant(a: Wires, b: &BigUint) -> Circuit {
-        assert_eq!(a.len(), N_BITS);
-        assert_ne!(b, &BigUint::ZERO);
-        let mut circuit = Circuit::empty();
-
-        let b_bits = bits_from_biguint(b);
-
-        let mut carry = new_wirex();
-        let mut first_one = 0;
-        while !b_bits[first_one] {
-            first_one += 1;
-        }
-
-        for i in 0..N_BITS {
-            if i < first_one {
-                circuit.add_wire(a[i].clone());
-            } else if i == first_one {
-                let wire = new_wirex();
-                circuit.add(Gate::not(a[i].clone(), wire.clone()));
-                circuit.add_wire(wire);
-                carry = a[i].clone();
-            } else if b_bits[i] {
-                let wire_1 = new_wirex();
-                let wire_2 = new_wirex();
-                circuit.add(Gate::xnor(a[i].clone(), carry.clone(), wire_1.clone()));
-                circuit.add(Gate::or(a[i].clone(), carry.clone(), wire_2.clone()));
-                circuit.add_wire(wire_1);
-                carry = wire_2;
-            } else {
-                let wire_1 = new_wirex();
-                let wire_2 = new_wirex();
-                circuit.add(Gate::xor(a[i].clone(), carry.clone(), wire_1.clone()));
-                circuit.add(Gate::and(a[i].clone(), carry.clone(), wire_2.clone()));
-                circuit.add_wire(wire_1);
-                carry = wire_2;
-            }
-        }
-        circuit.add_wire(carry);
-        circuit
+    pub fn add_without_carry(a: Wires, b: Wires) -> Circuit {
+        let mut c = add_generic(a, b, N_BITS);
+        c.0.pop();
+        c
     }
 
-    pub fn add_without_carry(a: Wires, b: Wires) -> Circuit {
-        assert_eq!(a.len(), N_BITS);
-        assert_eq!(b.len(), N_BITS);
-        let mut circuit = Circuit::empty();
-        let wires = circuit.extend(half_adder(a[0].clone(), b[0].clone()));
-        circuit.add_wire(wires[0].clone());
-        let mut carry = wires[1].clone();
-        for i in 1..N_BITS {
-            let wires = circuit.extend(full_adder(a[i].clone(), b[i].clone(), carry));
-            circuit.add_wire(wires[0].clone());
-            carry = wires[1].clone();
-        }
-        circuit
+    pub fn add_constant(a: Wires, b: &BigUint) -> Circuit {
+        add_constant_generic(a, b, N_BITS)
     }
 
     pub fn add_constant_without_carry(a: Wires, b: &BigUint) -> Circuit {
-        assert_eq!(a.len(), N_BITS);
-        assert_ne!(b, &BigUint::ZERO);
-        let mut circuit = Circuit::empty();
-
-        let b_bits = bits_from_biguint(b);
-
-        let mut carry = new_wirex();
-        let mut first_one = 0;
-        while !b_bits[first_one] {
-            first_one += 1;
-        }
-
-        for i in 0..N_BITS {
-            if i < first_one {
-                circuit.add_wire(a[i].clone());
-            } else if i == first_one {
-                let wire = new_wirex();
-                circuit.add(Gate::not(a[i].clone(), wire.clone()));
-                circuit.add_wire(wire);
-                carry = a[i].clone();
-            } else if b_bits[i] {
-                let wire_1 = new_wirex();
-                let wire_2 = new_wirex();
-                circuit.add(Gate::xnor(a[i].clone(), carry.clone(), wire_1.clone()));
-                circuit.add(Gate::or(a[i].clone(), carry.clone(), wire_2.clone()));
-                circuit.add_wire(wire_1);
-                carry = wire_2;
-            } else {
-                let wire_1 = new_wirex();
-                let wire_2 = new_wirex();
-                circuit.add(Gate::xor(a[i].clone(), carry.clone(), wire_1.clone()));
-                circuit.add(Gate::and(a[i].clone(), carry.clone(), wire_2.clone()));
-                circuit.add_wire(wire_1);
-                carry = wire_2;
-            }
-        }
-        circuit
+        let mut c = add_constant_generic(a, b, N_BITS);
+        c.0.pop();
+        c
     }
 
+    /*
     pub fn sub(a: Wires, b: Wires) -> Circuit {
-        optimized_sub_generic(a, b, false, N_BITS)
+        sub_generic(a, b, N_BITS)
     }
+    */
 
     pub fn sub_without_borrow(a: Wires, b: Wires) -> Circuit {
-        assert_eq!(a.len(), N_BITS);
-        assert_eq!(b.len(), N_BITS);
-        let mut circuit = Circuit::empty();
-        let wires = circuit.extend(half_subtracter(a[0].clone(), b[0].clone()));
-        circuit.add_wire(wires[0].clone());
-        let mut borrow = wires[1].clone();
-        for i in 1..N_BITS {
-            let wires = circuit.extend(full_subtracter(a[i].clone(), b[i].clone(), borrow));
-            circuit.add_wire(wires[0].clone());
-            borrow = wires[1].clone();
-        }
-        circuit
+        sub_generic_without_borrow(a, b, N_BITS)
     }
 
     pub fn double(a: Wires) -> Circuit {
@@ -254,7 +160,6 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         assert_eq!(a.len(), N_BITS);
         let mut circuit = Circuit::empty();
         let mut select = Self::wires();
-        let not_select = Self::wires();
         select[0] = a[0].clone();
         for i in 1..N_BITS {
             circuit.add(Gate::or(
@@ -264,17 +169,14 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
             ));
         }
 
-        for i in 0..N_BITS {
-            circuit.add(Gate::not(select[i].clone(), not_select[i].clone()));
-        }
-
         let mut k = Self::wires();
         k[0] = a[0].clone();
         for i in 1..N_BITS {
-            circuit.add(Gate::and(
-                not_select[i - 1].clone(),
+            circuit.add(Gate::and_variant(
+                select[i - 1].clone(),
                 a[i].clone(),
                 k[i].clone(),
+                [1, 0, 0],
             ));
         }
 
@@ -293,20 +195,13 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         circuit.add_wires(k.clone());
         circuit
     }
-
-    // This is optimized without not and xor optimizations, with them, it should be about the same
-    pub fn optimized_sub(a_wires: Wires, b_wires: Wires, check_bound: bool) -> Circuit {
-        optimized_sub_generic(a_wires, b_wires, check_bound, N_BITS)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::circuits::bigint::{
         U254,
-        utils::{
-            biguint_from_bits, biguint_from_wires, biguint_two_pow_254, random_biguint_n_bits,
-        },
+        utils::{biguint_from_wires, biguint_two_pow_254, random_biguint_n_bits},
     };
     use num_bigint::BigUint;
     use std::str::FromStr;
@@ -363,7 +258,7 @@ mod tests {
         if a < b {
             (a, b) = (b, a);
         }
-        let circuit = U254::sub(
+        let circuit = U254::sub_without_borrow(
             U254::wires_set_from_number(&a),
             U254::wires_set_from_number(&b),
         );
@@ -442,36 +337,5 @@ mod tests {
         let c = biguint_from_wires(circuit.0[0..U254::N_BITS].to_vec());
         let d = biguint_from_wires(circuit.0[U254::N_BITS..2 * U254::N_BITS].to_vec());
         assert_eq!(a, c * d);
-    }
-
-    #[test]
-    fn test_optimized_sub() {
-        for _ in 0..10 {
-            let a = random_biguint_n_bits(254);
-            let b = random_biguint_n_bits(254);
-            let mut circuit = U254::optimized_sub(
-                U254::wires_set_from_number(&a),
-                U254::wires_set_from_number(&b),
-                true,
-            );
-            circuit.gate_counts().print();
-            let bound_check = circuit.0.pop().unwrap();
-            let output_wires = circuit.0;
-            for mut gate in circuit.1 {
-                gate.evaluate();
-            }
-            if a < b {
-                assert!(!bound_check.borrow().get_value());
-            } else {
-                assert!(bound_check.borrow().get_value());
-                let result = biguint_from_bits(
-                    output_wires
-                        .iter()
-                        .map(|output_wire| output_wire.borrow().get_value())
-                        .collect(),
-                );
-                assert_eq!(result, a - b);
-            }
-        }
     }
 }

--- a/src/circuits/bigint/mul.rs
+++ b/src/circuits/bigint/mul.rs
@@ -2,7 +2,7 @@ use super::BigIntImpl;
 use crate::{
     bag::*,
     circuits::bigint::{
-        add::{add_generic, optimized_sub_generic},
+        add::{add_generic, sub_generic_without_borrow},
         cmp::self_or_zero_generic,
         utils::{bits_from_biguint, n_wires},
     },
@@ -111,13 +111,10 @@ pub fn mul_karatsuba_generic(a_wires: &Wires, b_wires: &Wires, len: usize) -> Ci
         //sq_sum.push(zero_wire.clone());
 
         let sum_mul = circuit.extend(mul_karatsuba_generic(&sum_a, &sum_b, len_1 + 1));
-        let cross_term = circuit.extend(optimized_sub_generic(
-            sum_mul,
-            sq_sum,
-            false,
-            (len_1 + 1) * 2,
-        ))[..(len + 1)]
-            .to_vec(); //len_0 + len_1 = len
+        let cross_term =
+            circuit.extend(sub_generic_without_borrow(sum_mul, sq_sum, (len_1 + 1) * 2))
+                [..(len + 1)]
+                .to_vec(); //len_0 + len_1 = len
 
         circuit.0[..(len_0 * 2)].clone_from_slice(&sq_0);
 

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -86,15 +86,18 @@ pub trait Fp254Impl {
         let c = Self::not_modulus_as_biguint();
         let mut wires_2 = circuit.extend(U254::add_constant(wires_1.clone(), &c));
         wires_2.pop();
-        let not_u = new_wirex();
-        circuit.add(Gate::not(u.clone(), not_u.clone()));
         let v = circuit.extend(U254::less_than_constant(
             wires_1.clone(),
             &Self::modulus_as_biguint(),
         ))[0]
             .clone();
         let s = new_wirex();
-        circuit.add(Gate::and(not_u.clone(), v.clone(), s.clone()));
+        circuit.add(Gate::and_variant(
+            u.clone(),
+            v.clone(),
+            s.clone(),
+            [1, 0, 0],
+        ));
         let wires_3 = circuit.extend(U254::select(wires_1, wires_2, s));
         circuit.add_wires(wires_3);
         circuit
@@ -114,15 +117,18 @@ pub trait Fp254Impl {
         let c = Self::not_modulus_as_biguint();
         let mut wires_2 = circuit.extend(U254::add_constant(wires_1.clone(), &c));
         wires_2.pop();
-        let not_u = new_wirex();
-        circuit.add(Gate::not(u.clone(), not_u.clone()));
         let v = circuit.extend(U254::less_than_constant(
             wires_1.clone(),
             &Self::modulus_as_biguint(),
         ))[0]
             .clone();
         let s = new_wirex();
-        circuit.add(Gate::and(not_u.clone(), v.clone(), s.clone()));
+        circuit.add(Gate::and_variant(
+            u.clone(),
+            v.clone(),
+            s.clone(),
+            [1, 0, 0],
+        ));
         let wires_3 = circuit.extend(U254::select(wires_1, wires_2, s));
         circuit.add_wires(wires_3);
         circuit
@@ -161,10 +167,13 @@ pub trait Fp254Impl {
         let mut circuit = Circuit::empty();
 
         let shift_wire = new_wirex();
+        /*
         let x = a[0].clone();
         let not_x = new_wirex();
         circuit.add(Gate::not(x.clone(), not_x.clone()));
         circuit.add(Gate::and(x.clone(), not_x.clone(), shift_wire.clone()));
+        */
+        shift_wire.borrow_mut().set(false);
         let mut aa = a.clone();
         let u = aa.pop().unwrap();
         let mut shifted_wires = vec![shift_wire];
@@ -172,15 +181,18 @@ pub trait Fp254Impl {
         let c = Self::not_modulus_as_biguint();
         let mut wires_2 = circuit.extend(U254::add_constant(shifted_wires.clone(), &c));
         wires_2.pop();
-        let not_u = new_wirex();
-        circuit.add(Gate::not(u.clone(), not_u.clone()));
         let v = circuit.extend(U254::less_than_constant(
             shifted_wires.clone(),
             &Self::modulus_as_biguint(),
         ))[0]
             .clone();
         let s = new_wirex();
-        circuit.add(Gate::and(not_u.clone(), v.clone(), s.clone()));
+        circuit.add(Gate::and_variant(
+            u.clone(),
+            v.clone(),
+            s.clone(),
+            [1, 0, 0],
+        ));
         let result = circuit.extend(U254::select(shifted_wires, wires_2, s));
         circuit.add_wires(result);
         circuit
@@ -244,8 +256,8 @@ pub trait Fp254Impl {
             &Self::modulus_as_biguint(),
             bound_check[0].clone(),
         ));
-        let new_sub = circuit.extend(U254::optimized_sub(sub, subtract_if_too_much, false));
-        let result = circuit.extend(U254::optimized_sub(x_high, new_sub, false));
+        let new_sub = circuit.extend(U254::sub_without_borrow(sub, subtract_if_too_much));
+        let result = circuit.extend(U254::sub_without_borrow(x_high, new_sub));
         circuit.add_wires(result);
 
         circuit
@@ -352,22 +364,27 @@ pub trait Fp254Impl {
         let mut s = Fq::wires_set(ark_bn254::Fq::from(2));
 
         for _ in 0..2 * Self::N_BITS {
-            let x1x = u[0].clone();
-            let x2x = v[0].clone();
-            let x1 = new_wirex();
-            let x2 = new_wirex();
-            circuit.add(Gate::not(x1x.clone(), x1.clone()));
-            circuit.add(Gate::not(x2x.clone(), x2.clone()));
+            let not_x1 = u[0].clone();
+            let not_x2 = v[0].clone();
+            //let x1 = new_wirex();
+            //let x2 = new_wirex();
+            //circuit.add(Gate::not(x1x.clone(), x1.clone()));
+            //circuit.add(Gate::not(x2x.clone(), x2.clone()));
             let x3 = circuit.extend(U254::greater_than(u.clone(), v.clone()))[0].clone();
 
-            let p1 = x1.clone();
-            let not_x1 = new_wirex();
-            circuit.add(Gate::not(x1.clone(), not_x1.clone()));
+            //let p1 = x1.clone();
+            //let not_x1 = new_wirex();
+            //circuit.add(Gate::not(x1.clone(), not_x1.clone()));
             let p2 = new_wirex();
-            circuit.add(Gate::and(not_x1.clone(), x2.clone(), p2.clone()));
+            circuit.add(Gate::and_variant(
+                not_x1.clone(),
+                not_x2.clone(),
+                p2.clone(),
+                [0, 1, 0],
+            ));
             let p3 = new_wirex();
-            let not_x2 = new_wirex();
-            circuit.add(Gate::not(x2, not_x2.clone()));
+            //let not_x2 = new_wirex();
+            //circuit.add(Gate::not(x2, not_x2.clone()));
             let wires_2 = new_wirex();
             circuit.add(Gate::and(not_x1.clone(), not_x2.clone(), wires_2.clone()));
             circuit.add(Gate::and(wires_2.clone(), x3.clone(), p3.clone()));
@@ -417,7 +434,7 @@ pub trait Fp254Impl {
             ));
 
             // calculate new u
-            let wire_u_1 = circuit.extend(U254::self_or_zero(u1.clone(), p1.clone()));
+            let wire_u_1 = circuit.extend(U254::self_or_zero_inv(u1.clone(), not_x1.clone()));
             let wire_u_2 = circuit.extend(U254::self_or_zero(u2.clone(), p2.clone()));
             let wire_u_3 = circuit.extend(U254::self_or_zero(u3.clone(), p3.clone()));
             let wire_u_4 = circuit.extend(U254::self_or_zero(u4.clone(), p4.clone()));
@@ -427,7 +444,7 @@ pub trait Fp254Impl {
             let new_u = circuit.extend(U254::add_without_carry(add_u_2, wire_u_4));
 
             // calculate new v
-            let wire_v_1 = circuit.extend(U254::self_or_zero(v1.clone(), p1.clone()));
+            let wire_v_1 = circuit.extend(U254::self_or_zero_inv(v1.clone(), not_x1.clone()));
             let wire_v_2 = circuit.extend(U254::self_or_zero(v2.clone(), p2.clone()));
             let wire_v_3 = circuit.extend(U254::self_or_zero(v3.clone(), p3.clone()));
             let wire_v_4 = circuit.extend(U254::self_or_zero(v4.clone(), p4.clone()));
@@ -437,7 +454,7 @@ pub trait Fp254Impl {
             let new_v = circuit.extend(U254::add_without_carry(add_v_2, wire_v_4));
 
             // calculate new r
-            let wire_r_1 = circuit.extend(U254::self_or_zero(r1.clone(), p1.clone()));
+            let wire_r_1 = circuit.extend(U254::self_or_zero_inv(r1.clone(), not_x1.clone()));
             let wire_r_2 = circuit.extend(U254::self_or_zero(r2.clone(), p2.clone()));
             let wire_r_3 = circuit.extend(U254::self_or_zero(r3.clone(), p3.clone()));
             let wire_r_4 = circuit.extend(U254::self_or_zero(r4.clone(), p4.clone()));
@@ -447,7 +464,7 @@ pub trait Fp254Impl {
             let new_r = circuit.extend(U254::add_without_carry(add_r_2, wire_r_4));
 
             // calculate new s
-            let wire_s_1 = circuit.extend(U254::self_or_zero(s1.clone(), p1.clone()));
+            let wire_s_1 = circuit.extend(U254::self_or_zero_inv(s1.clone(), not_x1.clone()));
             let wire_s_2 = circuit.extend(U254::self_or_zero(s2.clone(), p2.clone()));
             let wire_s_3 = circuit.extend(U254::self_or_zero(s3.clone(), p3.clone()));
             let wire_s_4 = circuit.extend(U254::self_or_zero(s4.clone(), p4.clone()));
@@ -457,7 +474,7 @@ pub trait Fp254Impl {
             let new_s = circuit.extend(U254::add_without_carry(add_s_2, wire_s_4));
 
             // calculate new k
-            let wire_k_1 = circuit.extend(U254::self_or_zero(k1.clone(), p1.clone()));
+            let wire_k_1 = circuit.extend(U254::self_or_zero_inv(k1.clone(), not_x1.clone()));
             let wire_k_2 = circuit.extend(U254::self_or_zero(k2.clone(), p2.clone()));
             let wire_k_3 = circuit.extend(U254::self_or_zero(k3.clone(), p3.clone()));
             let wire_k_4 = circuit.extend(U254::self_or_zero(k4.clone(), p4.clone()));

--- a/src/core/bristol.rs
+++ b/src/core/bristol.rs
@@ -55,7 +55,6 @@ pub fn parser(filename: &str) -> (Circuit, Vec<Wires>, Vec<Wires>) {
             "inv" | "not" => GateType::Not,
             "xnor" => GateType::Xnor,
             "nimp" => GateType::Nimp,
-            "nsor" => GateType::Nsor,
             _ => panic!("Unknown gate type: {}", gate_type_str),
         };
         let gate = Gate::new(

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -1,7 +1,4 @@
-use crate::{
-    bag::*,
-    core::gate::{GateCount, GateType},
-};
+use crate::{bag::*, core::gate::GateCount};
 
 pub struct Circuit(pub Wires, pub Vec<Gate>);
 
@@ -41,20 +38,9 @@ impl Circuit {
 
     pub fn gate_counts(&self) -> GateCount {
         let mut gc = GateCount::default();
-
         for gate in self.1.iter() {
-            match gate.gate_type {
-                GateType::And => gc.and += 1,
-                GateType::Or => gc.or += 1,
-                GateType::Xor => gc.xor += 1,
-                GateType::Nand => gc.nand += 1,
-                GateType::Not => gc.not += 1,
-                GateType::Xnor => gc.xnor += 1,
-                GateType::Nimp => gc.nimp += 1,
-                GateType::Nsor => gc.nsor += 1,
-            }
+            gc.0[gate.gate_type as usize] += 1;
         }
-
         gc
     }
 }

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -3,18 +3,43 @@ use crate::core::utils::{LIMB_LEN, N_LIMBS, bit_to_usize, convert_between_blake3
 use bitvm::{bigint::U256, hash::blake3::blake3_compute_script_with_limb, treepp::*};
 use std::ops::{Add, AddAssign};
 
+// Except Xor, Xnor and Not, each enum's bitmask represent the boolean operation ((a XOR bit_2) AND (b XOR bit_1)) XOR bit_0
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GateType {
     And = 0,
-    Or,
+    Nand = 1,
+    Nimp = 2,
+    Imp = 3, // a => b
+    Ncimp = 4,
+    Cimp = 5, // b => a
+    Nor = 6,
+    Or = 7,
     Xor,
-    Nand,
-    Not,
     Xnor,
-    Nimp,
-    Nsor,
+    Not,
 }
+
+// only for and variants
+impl TryFrom<u8> for GateType {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(GateType::And),
+            1 => Ok(GateType::Nand),
+            2 => Ok(GateType::Nimp),
+            3 => Ok(GateType::Imp),
+            4 => Ok(GateType::Ncimp),
+            5 => Ok(GateType::Cimp),
+            6 => Ok(GateType::Nor),
+            7 => Ok(GateType::Or),
+            _ => Err(()),
+        }
+    }
+}
+
+const GATE_TYPE_COUNT: usize = 11;
 
 #[derive(Clone)]
 pub struct Gate {
@@ -55,6 +80,46 @@ impl Gate {
         Self::new(wire_a, wire_b, wire_c, GateType::Nand)
     }
 
+    pub fn nimp(
+        wire_a: Rc<RefCell<Wire>>,
+        wire_b: Rc<RefCell<Wire>>,
+        wire_c: Rc<RefCell<Wire>>,
+    ) -> Self {
+        Self::new(wire_a, wire_b, wire_c, GateType::Nimp)
+    }
+
+    pub fn imp(
+        wire_a: Rc<RefCell<Wire>>,
+        wire_b: Rc<RefCell<Wire>>,
+        wire_c: Rc<RefCell<Wire>>,
+    ) -> Self {
+        Self::new(wire_a, wire_b, wire_c, GateType::Imp)
+    }
+
+    pub fn ncimp(
+        wire_a: Rc<RefCell<Wire>>,
+        wire_b: Rc<RefCell<Wire>>,
+        wire_c: Rc<RefCell<Wire>>,
+    ) -> Self {
+        Self::new(wire_a, wire_b, wire_c, GateType::Ncimp)
+    }
+
+    pub fn cimp(
+        wire_a: Rc<RefCell<Wire>>,
+        wire_b: Rc<RefCell<Wire>>,
+        wire_c: Rc<RefCell<Wire>>,
+    ) -> Self {
+        Self::new(wire_a, wire_b, wire_c, GateType::Cimp)
+    }
+
+    pub fn nor(
+        wire_a: Rc<RefCell<Wire>>,
+        wire_b: Rc<RefCell<Wire>>,
+        wire_c: Rc<RefCell<Wire>>,
+    ) -> Self {
+        Self::new(wire_a, wire_b, wire_c, GateType::Nor)
+    }
+
     pub fn or(
         wire_a: Rc<RefCell<Wire>>,
         wire_b: Rc<RefCell<Wire>>,
@@ -80,88 +145,63 @@ impl Gate {
     }
 
     pub fn not(wire_a: Rc<RefCell<Wire>>, wire_c: Rc<RefCell<Wire>>) -> Self {
-        Self::new(wire_a.clone(), wire_a.clone(), wire_c, GateType::Not)
+        Self::new(wire_a.clone(), wire_a, wire_c, GateType::Not)
     }
 
-    pub fn nimp(
+    //((a XOR f_0) AND (b XOR bit_1)) XOR f_2
+    pub fn and_variant(
         wire_a: Rc<RefCell<Wire>>,
         wire_b: Rc<RefCell<Wire>>,
         wire_c: Rc<RefCell<Wire>>,
+        f: [u8; 3],
     ) -> Self {
-        Self::new(wire_a.clone(), wire_b.clone(), wire_c, GateType::Nimp)
-    }
-
-    pub fn nsor(
-        wire_a: Rc<RefCell<Wire>>,
-        wire_b: Rc<RefCell<Wire>>,
-        wire_c: Rc<RefCell<Wire>>,
-    ) -> Self {
-        Self::new(wire_a.clone(), wire_b.clone(), wire_c, GateType::Nsor)
+        let gate_index = (f[0] << 2) | (f[1] << 1) | f[2];
+        let gate_type = match GateType::try_from(gate_index) {
+            Ok(gt) => gt,
+            Err(_) => panic!("Invalid gate type index: {}", gate_index),
+        };
+        Self::new(wire_a, wire_b, wire_c, gate_type)
     }
 
     pub fn f(&self) -> fn(bool, bool) -> bool {
         match self.gate_type {
-            GateType::And => {
-                fn and(a: bool, b: bool) -> bool {
-                    a & b
-                }
-                and
-            }
-            GateType::Or => {
-                fn or(a: bool, b: bool) -> bool {
-                    a | b
-                }
-                or
-            }
-            GateType::Xor => {
-                fn xor(a: bool, b: bool) -> bool {
-                    a ^ b
-                }
-                xor
-            }
-            GateType::Nand => {
-                fn nand(a: bool, b: bool) -> bool {
-                    !(a & b)
-                }
-                nand
-            }
-            GateType::Not => {
-                fn not(a: bool, _b: bool) -> bool {
-                    !a
-                }
-                not
-            }
-            GateType::Xnor => {
-                fn xnor(a: bool, b: bool) -> bool {
-                    !(a ^ b)
-                }
-                xnor
-            }
-            GateType::Nimp => {
-                fn nimp(a: bool, b: bool) -> bool {
-                    (a) && (!b)
-                }
-                nimp
-            }
-            GateType::Nsor => {
-                fn nsor(a: bool, b: bool) -> bool {
-                    a | (!b)
-                }
-                nsor
-            }
+            GateType::And => |a, b| a & b,
+            GateType::Nand => |a, b| !(a & b),
+
+            GateType::Nimp => |a, b| a & !b,
+            GateType::Imp => |a, b| !a | b,
+
+            GateType::Ncimp => |a, b| !a & b,
+            GateType::Cimp => |a, b| !b | a,
+
+            GateType::Nor => |a, b| !(a | b),
+            GateType::Or => |a, b| a | b,
+
+            GateType::Xor => |a, b| a ^ b,
+            GateType::Xnor => |a, b| !(a ^ b),
+
+            GateType::Not => |a, _| !a,
         }
     }
 
     pub fn evaluation_script(&self) -> Script {
         match self.gate_type {
             GateType::And => script! { OP_BOOLAND },
-            GateType::Or => script! { OP_BOOLOR },
-            GateType::Xor => script! { OP_NUMNOTEQUAL },
             GateType::Nand => script! { OP_BOOLAND OP_NOT },
-            GateType::Not => script! { OP_DROP OP_NOT },
+
+            GateType::Nimp => script! { OP_SWAP OP_NOT OP_BOOLAND },
+            GateType::Imp => script! { OP_NOT OP_SWAP OP_BOOLOR },
+
+            GateType::Ncimp => script! { OP_NOT OP_BOOLAND },
+            GateType::Cimp => script! { OP_SWAP OP_NOT OP_BOOLOR },
+
+            GateType::Nor => script! { OP_BOOLOR OP_NOT },
+            GateType::Or => script! { OP_BOOLOR },
+
+            GateType::Xor => script! { OP_NUMNOTEQUAL },
             GateType::Xnor => script! { OP_NUMNOTEQUAL OP_NOT },
-            GateType::Nimp => script! { OP_NOT OP_BOOLAND },
-            GateType::Nsor => script! { OP_NOT OP_BOOLOR},
+
+            GateType::Not => script! { OP_DROP OP_NOT },
         }
     }
 
@@ -267,87 +307,71 @@ impl Gate {
 }
 
 #[derive(Default)]
-pub struct GateCount {
-    pub and: usize,
-    pub or: usize,
-    pub xor: usize,
-    pub nand: usize,
-    pub not: usize,
-    pub xnor: usize,
-    pub nimp: usize,
-    pub nsor: usize,
-}
+pub struct GateCount(pub [u64; GATE_TYPE_COUNT]);
 
 impl Add for GateCount {
     type Output = Self;
 
     fn add(self, other: Self) -> Self::Output {
-        Self {
-            and: self.and + other.and,
-            or: self.or + other.or,
-            xor: self.xor + other.xor,
-            nand: self.nand + other.nand,
-            not: self.not + other.not,
-            xnor: self.xnor + other.xnor,
-            nimp: self.nimp + other.nimp,
-            nsor: self.nsor + other.nsor,
+        let mut result = [0u64; GATE_TYPE_COUNT];
+        for (i, r) in result.iter_mut().enumerate() {
+            *r = self.0[i] + other.0[i];
         }
+        GateCount(result)
     }
 }
 
 impl AddAssign for GateCount {
     fn add_assign(&mut self, other: Self) {
-        self.and = self.and + other.and;
-        self.or = self.or + other.or;
-        self.xor = self.xor + other.xor;
-        self.nand = self.nand + other.nand;
-        self.not = self.not + other.not;
-        self.xnor = self.xnor + other.xnor;
-        self.nimp = self.nimp + other.nimp;
-        self.nsor = self.nsor + other.nsor;
+        for i in 0..GATE_TYPE_COUNT {
+            self.0[i] += other.0[i];
+        }
     }
 }
 
 impl GateCount {
     pub fn zero() -> Self {
-        Self {
-            and: 0,
-            or: 0,
-            xor: 0,
-            nand: 0,
-            not: 0,
-            xnor: 0,
-            nimp: 0,
-            nsor: 0,
+        Self([0; GATE_TYPE_COUNT])
+    }
+
+    pub fn total_gate_count(&self) -> u64 {
+        let mut sum = 0u64;
+        for x in self.0 {
+            sum += x;
         }
+        sum
     }
 
-    pub fn total_gate_count(&self) -> usize {
-        self.and + self.or + self.xor + self.nand + self.not + self.xnor + self.nimp + self.nsor
+    fn and_variants_count(&self) -> u64 {
+        let mut sum = 0u64;
+        for x in &self.0[0..8] {
+            sum += x;
+        }
+        sum
     }
 
-    pub fn nonfree_gate_count(&self) -> usize {
-        self.and + self.or + self.nand + self.nimp + self.nsor
+    pub fn nonfree_gate_count(&self) -> u64 {
+        self.and_variants_count() + self.0[GateType::Not as usize]
+    }
+
+    fn xor_variants_count(&self) -> u64 {
+        self.0[GateType::Xor as usize] + self.0[GateType::Xnor as usize]
     }
 
     pub fn print(&self) {
-        println!("and:  {:?}", self.and);
-        println!("or:   {:?}", self.or);
-        println!("xor:  {:?}", self.xor);
-        println!("nand: {:?}", self.nand);
-        println!("not:  {:?}", self.not);
-        println!("xnor: {:?}", self.xnor);
-        println!("nimp: {:?}", self.nimp);
-        println!("nsor: {:?}", self.nsor);
-        println!();
-        println!("total: {:?}", self.total_gate_count());
-        println!("nonfree: {:?}", self.nonfree_gate_count());
+        println!("{:?}", self.0);
+        println!("and variants:  {:?}", self.and_variants_count());
+        println!("xor variants:  {:?}", self.xor_variants_count());
+        println!("not:           {:?}", self.0[GateType::Not as usize]);
+        println!("total:         {:?}", self.total_gate_count());
+        println!("nonfree:       {:?}\n", self.nonfree_gate_count());
     }
 }
 
 // these are here to speed up tests
 impl GateCount {
     pub fn msm() -> Self {
+        /*
         Self {
             and: 128808400,
             or: 51296850,
@@ -357,23 +381,16 @@ impl GateCount {
             xnor: 51296850,
             nimp: 0,
             nsor: 0,
-        }
+        } */
+        Self::zero()
     }
 
     pub fn msm_montgomery() -> Self {
-        Self {
-            and: 40965250,
-            or: 89650,
-            xor: 123958925,
-            nand: 58898790,
-            not: 19856230,
-            xnor: 89650,
-            nimp: 1078400,
-            nsor: 0,
-        }
+        todo!()
     }
 
     pub fn fq12_square() -> Self {
+        /*
         Self {
             and: 9875584,
             or: 3951608,
@@ -384,22 +401,16 @@ impl GateCount {
             nimp: 0,
             nsor: 0,
         }
+        */
+        Self::zero()
     }
 
     pub fn fq12_square_montgomery() -> Self {
-        Self {
-            and: 3235040,
-            or: 111068,
-            xor: 9610884,
-            nand: 344424,
-            not: 247730,
-            xnor: 108020,
-            nimp: 80880,
-            nsor: 0,
-        }
+        todo!();
     }
 
     pub fn fq12_cyclotomic_square() -> Self {
+        /*
         Self {
             and: 5903509,
             or: 2357575,
@@ -410,22 +421,16 @@ impl GateCount {
             nimp: 0,
             nsor: 0,
         }
+        */
+        Self::zero()
     }
 
     pub fn fq12_cyclotomic_square_montgomery() -> Self {
-        Self {
-            and: 1921915,
-            or: 53251,
-            xor: 5742928,
-            nand: 150114,
-            not: 113190,
-            xnor: 53251,
-            nimp: 48528,
-            nsor: 0,
-        }
+        todo!()
     }
 
     pub fn fq12_mul() -> Self {
+        /*
         Self {
             and: 14793358,
             or: 5916742,
@@ -436,22 +441,16 @@ impl GateCount {
             nimp: 0,
             nsor: 0,
         }
+        */
+        Self::zero()
     }
 
     pub fn fq12_mul_montgomery() -> Self {
-        Self {
-            and: 4837096,
-            or: 155932,
-            xor: 14387257,
-            nand: 486156,
-            not: 349863,
-            xnor: 151360,
-            nimp: 121320,
-            nsor: 0,
-        }
+        todo!()
     }
 
     pub fn fq12_inverse() -> Self {
+        /*
         Self {
             and: 37917672,
             or: 12127813,
@@ -462,22 +461,16 @@ impl GateCount {
             nimp: 0,
             nsor: 0,
         }
+        */
+        Self::zero()
     }
 
     pub fn fq12_inverse_montgomery() -> Self {
-        Self {
-            and: 16055254,
-            or: 477163,
-            xor: 39293240,
-            nand: 4991100,
-            not: 3002469,
-            xnor: 473862,
-            nimp: 240452,
-            nsor: 0,
-        }
+        todo!()
     }
 
     pub fn double_in_place() -> Self {
+        /*
         Self {
             and: 7285002,
             or: 3000110,
@@ -488,22 +481,16 @@ impl GateCount {
             nimp: 0,
             nsor: 0,
         }
+        */
+        Self::zero()
     }
 
     pub fn double_in_place_montgomery() -> Self {
-        Self {
-            and: 2414576,
-            or: 26095,
-            xor: 7491460,
-            nand: 72390,
-            not: 59755,
-            xnor: 26095,
-            nimp: 58140,
-            nsor: 0,
-        }
+        todo!()
     }
 
     pub fn add_in_place() -> Self {
+        /*
         Self {
             and: 11969527,
             or: 4769941,
@@ -514,22 +501,16 @@ impl GateCount {
             nimp: 0,
             nsor: 0,
         }
+        */
+        Self::zero()
     }
 
     pub fn add_in_place_montgomery() -> Self {
-        Self {
-            and: 3829077,
-            or: 33275,
-            xor: 11551949,
-            nand: 87630,
-            not: 77857,
-            xnor: 33275,
-            nimp: 99752,
-            nsor: 0,
-        }
+        todo!()
     }
 
     pub fn ell() -> Self {
+        /*
         Self {
             and: 13963948,
             or: 5564020,
@@ -540,22 +521,16 @@ impl GateCount {
             nimp: 0,
             nsor: 0,
         }
+        */
+        Self::zero()
     }
 
     pub fn ell_montgomery() -> Self {
-        Self {
-            and: 4487192,
-            or: 59246,
-            xor: 13511035,
-            nand: 161544,
-            not: 132271,
-            xnor: 59246,
-            nimp: 115928,
-            nsor: 0,
-        }
+        todo!()
     }
 
     pub fn ell_by_constant() -> Self {
+        /*
         Self {
             and: 11438002,
             or: 5060584,
@@ -566,19 +541,12 @@ impl GateCount {
             nimp: 0,
             nsor: 0,
         }
+        */
+        Self::zero()
     }
 
     pub fn ell_by_constant_montgomery() -> Self {
-        Self {
-            and: 4099084,
-            or: 58734,
-            xor: 13500973,
-            nand: 158496,
-            not: 130231,
-            xnor: 58734,
-            nimp: 80920,
-            nsor: 0,
-        }
+        todo!()
     }
 }
 

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -20,7 +20,7 @@ pub enum GateType {
     Not,
 }
 
-// only for and variants
+// only for AND variants
 impl TryFrom<u8> for GateType {
     type Error = ();
 
@@ -351,7 +351,7 @@ impl GateCount {
     }
 
     pub fn nonfree_gate_count(&self) -> u64 {
-        self.and_variants_count() + self.0[GateType::Not as usize]
+        self.and_variants_count()
     }
 
     fn xor_variants_count(&self) -> u64 {
@@ -360,11 +360,12 @@ impl GateCount {
 
     pub fn print(&self) {
         println!("{:?}", self.0);
-        println!("and variants:  {:?}", self.and_variants_count());
-        println!("xor variants:  {:?}", self.xor_variants_count());
-        println!("not:           {:?}", self.0[GateType::Not as usize]);
-        println!("total:         {:?}", self.total_gate_count());
-        println!("nonfree:       {:?}\n", self.nonfree_gate_count());
+        println!("{:<15}{:>11}", "and variants:", self.and_variants_count());
+        println!("{:<15}{:>11}", "xor variants:", self.xor_variants_count());
+        println!("{:<15}{:>11}", "not:", self.0[GateType::Not as usize]);
+        println!("{:<15}{:>11}", "total:", self.total_gate_count());
+        println!()
+        //println!("nonfree:       {:?}\n", self.nonfree_gate_count()); //equals to and variants
     }
 }
 
@@ -386,7 +387,9 @@ impl GateCount {
     }
 
     pub fn msm_montgomery() -> Self {
-        todo!()
+        Self([
+            40952275, 39265860, 0, 0, 29750, 19632930, 0, 89650, 125020525, 89700, 210275,
+        ])
     }
 
     pub fn fq12_square() -> Self {
@@ -406,7 +409,9 @@ impl GateCount {
     }
 
     pub fn fq12_square_montgomery() -> Self {
-        todo!();
+        Self([
+            3234570, 229616, 0, 0, 1640, 114808, 0, 111068, 9690504, 108020, 132452,
+        ])
     }
 
     pub fn fq12_cyclotomic_square() -> Self {
@@ -426,7 +431,9 @@ impl GateCount {
     }
 
     pub fn fq12_cyclotomic_square_montgomery() -> Self {
-        todo!()
+        Self([
+            1921672, 100076, 0, 0, 953, 50038, 0, 53251, 5790700, 53251, 62909,
+        ])
     }
 
     pub fn fq12_mul() -> Self {
@@ -446,7 +453,9 @@ impl GateCount {
     }
 
     pub fn fq12_mul_montgomery() -> Self {
-        todo!()
+        Self([
+            4836448, 324104, 0, 0, 2420, 162052, 0, 155932, 14506687, 151360, 187163,
+        ])
     }
 
     pub fn fq12_inverse() -> Self {
@@ -466,7 +475,9 @@ impl GateCount {
     }
 
     pub fn fq12_inverse_montgomery() -> Self {
-        todo!()
+        Self([
+            14828696, 3327400, 645668, 0, 327459, 1663700, 0, 477163, 39787000, 474370, 498290,
+        ])
     }
 
     pub fn double_in_place() -> Self {
@@ -486,7 +497,9 @@ impl GateCount {
     }
 
     pub fn double_in_place_montgomery() -> Self {
-        todo!()
+        Self([
+            2414471, 48260, 0, 0, 979, 24130, 0, 26095, 7548712, 26095, 35520,
+        ])
     }
 
     pub fn add_in_place() -> Self {
@@ -506,7 +519,9 @@ impl GateCount {
     }
 
     pub fn add_in_place_montgomery() -> Self {
-        todo!()
+        Self([
+            3828958, 58420, 0, 0, 1669, 29210, 0, 33275, 11650147, 33275, 48528,
+        ])
     }
 
     pub fn ell() -> Self {
@@ -526,7 +541,9 @@ impl GateCount {
     }
 
     pub fn ell_montgomery() -> Self {
-        todo!()
+        Self([
+            4486968, 107696, 0, 0, 2018, 53848, 0, 59246, 13625157, 59246, 78199,
+        ])
     }
 
     pub fn ell_by_constant() -> Self {
@@ -546,7 +563,9 @@ impl GateCount {
     }
 
     pub fn ell_by_constant_montgomery() -> Self {
-        todo!()
+        Self([
+            4098864, 105664, 0, 0, 1374, 52832, 0, 58734, 13580727, 58734, 77179,
+        ])
     }
 }
 


### PR DESCRIPTION
This PR expands the work of #23 for subtractions. It also adds all the gate types and removes most of the NOT operations (Rest of them can also be removed, but they require adding/copy pasting new variants of some functions with built-in NOT's, which is the subject of further discussion since they can also be handled with an automatic remover after the construction)