### PR TITLE
ci: Add automated gate count tracking with CI badges

### DIFF
--- a/.github/workflows/gate-count-badges.yml
+++ b/.github/workflows/gate-count-badges.yml
@@ -1,0 +1,134 @@
+name: Update Gate Count Badges
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  gate-count:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Rust 1.88.0
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: "1.88.0"
+        override: true
+    
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
+    
+    - name: Cache cargo dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    
+    - name: Run gate count examples
+      run: |
+        echo "Running gate count..."
+        set -e  # Exit on any error
+        
+        # Run the example and capture output
+        cargo run --example groth16_gc_gate_count --release -- --json > raw_output.txt 2>&1
+        
+        echo "Raw output from cargo run:"
+        cat raw_output.txt
+        
+        # Extract JSON and validate
+        sed -n '/^{/,$p' raw_output.txt > gates.json
+        
+        echo "Extracted JSON:"
+        cat gates.json
+        
+        # Validate JSON structure
+        if ! jq empty gates.json; then
+          echo "ERROR: Invalid JSON structure in gates.json"
+          echo "Content of gates.json:"
+          cat gates.json
+          exit 1
+        fi
+        
+        # Validate required fields exist
+        if ! jq -e '.gate_count.total_formatted' gates.json >/dev/null; then
+          echo "ERROR: Missing .gate_count.total_formatted in JSON"
+          echo "Available keys in gate_count:"
+          jq -r '.gate_count | keys[]' gates.json || echo "No gate_count object found"
+          echo "Full JSON structure:"
+          jq . gates.json
+          exit 1
+        fi
+        
+        echo "JSON validation successful"
+    
+    - name: Extract gate counts and create badges
+      run: |
+        set -e  # Exit on any error
+        
+        # Extract formatted gate counts from JSON with validation
+        echo "Extracting gate counts from JSON..."
+        
+        TOTAL=$(jq -r '.gate_count.total_formatted' gates.json)
+        NONFREE=$(jq -r '.gate_count.nonfree_formatted' gates.json)
+        FREE=$(jq -r '.gate_count.free_formatted' gates.json)
+        
+        # Validate that we got actual values, not null or empty
+        if [ "$TOTAL" = "null" ] || [ "$TOTAL" = "" ]; then
+          echo "ERROR: Failed to extract total_formatted from JSON"
+          echo "gates.json content:"
+          cat gates.json
+          exit 1
+        fi
+        
+        if [ "$NONFREE" = "null" ] || [ "$NONFREE" = "" ]; then
+          echo "ERROR: Failed to extract nonfree_formatted from JSON"
+          echo "gates.json content:"
+          cat gates.json
+          exit 1
+        fi
+        
+        if [ "$FREE" = "null" ] || [ "$FREE" = "" ]; then
+          echo "ERROR: Failed to extract free_formatted from JSON"
+          echo "gates.json content:"
+          cat gates.json
+          exit 1
+        fi
+        
+        echo "Successfully extracted gate counts:"
+        echo "  Total: $TOTAL"
+        echo "  Non-Free: $NONFREE"
+        echo "  Free: $FREE"
+        
+        # Create badge JSON files for shields.io endpoint
+        mkdir -p badge_data
+        
+        # Create shields.io endpoint format JSON files
+        echo "{\"schemaVersion\": 1, \"label\": \"Total Gates\", \"message\": \"${TOTAL}\", \"color\": \"blue\"}" > badge_data/total.json
+        echo "{\"schemaVersion\": 1, \"label\": \"Non-Free Gates\", \"message\": \"${NONFREE}\", \"color\": \"red\"}" > badge_data/nonfree.json
+        echo "{\"schemaVersion\": 1, \"label\": \"Free Gates\", \"message\": \"${FREE}\", \"color\": \"green\"}" > badge_data/free.json
+        
+        # Display badge data
+        echo "Badge data created:"
+        ls -la badge_data/
+        for file in badge_data/*.json; do
+          echo "$(basename $file .json): $(cat $file)"
+        done
+    
+    - name: Upload gate count artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: gate-counts
+        path: badge_data
+
+    - name: Deploy badge JSONs to gh-badges branch
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./badge_data
+        publish_branch: gh-badges
+        destination_dir: badge_data

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Garbled SNARK Verifier Circuit
 
+## Gate Count Metrics
+
+Gate counts are automatically measured for k=6 (64 constraints) on every push to `main` and published as dynamic badges.
+
+![Total Gates](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/BitVM/garbled-snark-verifier/gh-badges/badge_data/total.json)
+![Non-Free Gates](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/BitVM/garbled-snark-verifier/gh-badges/badge_data/nonfree.json)
+![Free Gates](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/BitVM/garbled-snark-verifier/gh-badges/badge_data/free.json)
+
+---
+
 A: operator, B: verifier
 
 0. A and B agree on the circuit.

--- a/examples/groth16_gc_gate_count.rs
+++ b/examples/groth16_gc_gate_count.rs
@@ -1,0 +1,134 @@
+use std::env;
+
+use ark_crypto_primitives::snark::{CircuitSpecificSetupSNARK, SNARK};
+use ark_ec::pairing::Pairing;
+use ark_ff::{PrimeField, UniformRand};
+use ark_groth16::Groth16;
+use ark_relations::{
+    lc,
+    r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
+};
+use ark_std::{
+    rand::{RngCore, SeedableRng},
+    test_rng,
+};
+
+use garbled_snark_verifier::circuits::{
+    bn254::{fr::Fr, g1::G1Affine, g2::G2Affine},
+    groth16::groth16_verifier_evaluate_montgomery,
+};
+use itertools::Itertools;
+use serde_json::json;
+
+/// Format large numbers in human-readable format (M for millions, B for billions)
+fn format_number(n: u64) -> String {
+    if n >= 1_000_000_000 {
+        format!("{:.1}B", n as f64 / 1_000_000_000.0)
+    } else if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+/// Circuit size parameter k, where the number of constraints = 2^k
+/// k = 6 means 2^6 = 64 constraints for the test circuit
+const K: usize = 6;
+
+#[derive(Copy, Clone)]
+struct DummyCircuit<F: PrimeField> {
+    pub a: Option<F>,
+    pub b: Option<F>,
+    pub num_variables: usize,
+    pub num_constraints: usize,
+}
+
+impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
+    fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
+        let a = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+        let b = cs.new_witness_variable(|| self.b.ok_or(SynthesisError::AssignmentMissing))?;
+        let c = cs.new_input_variable(|| {
+            let a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
+            let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
+
+            Ok(a * b)
+        })?;
+
+        for _ in 0..(self.num_variables - 3) {
+            let _ = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+        }
+
+        for _ in 0..self.num_constraints - 1 {
+            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        }
+
+        cs.enforce_constraint(lc!(), lc!(), lc!())?;
+
+        Ok(())
+    }
+}
+
+fn main() {
+    let json_output = env::args().contains(&"--json".to_owned());
+
+    if !json_output {
+        println!("Running Groth16 verifier gate count example");
+        println!("Circuit size: k = {}, constraints = {}", K, 1 << K);
+    }
+
+    let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
+    let circuit = DummyCircuit::<<ark_bn254::Bn254 as Pairing>::ScalarField> {
+        a: Some(<ark_bn254::Bn254 as Pairing>::ScalarField::rand(&mut rng)),
+        b: Some(<ark_bn254::Bn254 as Pairing>::ScalarField::rand(&mut rng)),
+        num_variables: 10,
+        num_constraints: 1 << K,
+    };
+    let (pk, vk) = Groth16::<ark_bn254::Bn254>::setup(circuit, &mut rng).unwrap();
+
+    let c = circuit.a.unwrap() * circuit.b.unwrap();
+
+    let proof = Groth16::<ark_bn254::Bn254>::prove(&pk, circuit, &mut rng).unwrap();
+
+    if !json_output {
+        println!("Setup and proof generation completed");
+    }
+
+    let public = Fr::wires_set(c);
+    let proof_a = G1Affine::wires_set_montgomery(proof.a);
+    let proof_b = G2Affine::wires_set_montgomery(proof.b);
+    let proof_c = G1Affine::wires_set_montgomery(proof.c);
+    let (result, gate_count) =
+        groth16_verifier_evaluate_montgomery(public, proof_a, proof_b, proof_c, vk, false);
+
+    if json_output {
+        let nonfree_gates = gate_count.nonfree_gate_count();
+        let xor_variants = gate_count.xor_count() + gate_count.xnor_count();
+        let not_gates = gate_count.not_count();
+        let free_gates = xor_variants + not_gates;
+        let total_gates = gate_count.total_gate_count();
+
+        let output = json!({
+            "circuit_size": {
+                "k": K,
+                "constraints": 1 << K
+            },
+            "gate_count": {
+                "nonfree": nonfree_gates,
+                "nonfree_formatted": format_number(nonfree_gates),
+                "free": free_gates,
+                "free_formatted": format_number(free_gates),
+                "total": total_gates,
+                "total_formatted": format_number(total_gates),
+                "breakdown": gate_count.0
+            },
+            "verification_result": result.borrow().get_value()
+        });
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    } else {
+        println!("\n=== GATE COUNT ===");
+        gate_count.print();
+        println!("Verification result: {}", result.borrow().get_value());
+    }
+}

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -50,12 +50,7 @@ pub struct Gate {
 }
 
 impl Gate {
-    pub fn new(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-        gate_type: GateType,
-    ) -> Self {
+    pub fn new(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex, gate_type: GateType) -> Self {
         Self {
             wire_a,
             wire_b,
@@ -64,83 +59,43 @@ impl Gate {
         }
     }
 
-    pub fn and(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn and(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::And)
     }
 
-    pub fn nand(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn nand(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::Nand)
     }
 
-    pub fn nimp(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn nimp(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::Nimp)
     }
 
-    pub fn imp(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn imp(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::Imp)
     }
 
-    pub fn ncimp(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn ncimp(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::Ncimp)
     }
 
-    pub fn cimp(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn cimp(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::Cimp)
     }
 
-    pub fn nor(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn nor(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::Nor)
     }
 
-    pub fn or(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn or(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::Or)
     }
 
-    pub fn xor(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn xor(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::Xor)
     }
 
-    pub fn xnor(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-    ) -> Self {
+    pub fn xnor(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex) -> Self {
         Self::new(wire_a, wire_b, wire_c, GateType::Xnor)
     }
 
@@ -149,12 +104,7 @@ impl Gate {
     }
 
     //((a XOR f_0) AND (b XOR f_1)) XOR f_2
-    pub fn and_variant(
-        wire_a: Wirex,
-        wire_b: Wirex,
-        wire_c: Wirex,
-        f: [u8; 3],
-    ) -> Self {
+    pub fn and_variant(wire_a: Wirex, wire_b: Wirex, wire_c: Wirex, f: [u8; 3]) -> Self {
         let gate_index = (f[0] << 2) | (f[1] << 1) | f[2];
         let gate_type = match GateType::try_from(gate_index) {
             Ok(gt) => gt,
@@ -366,6 +316,50 @@ impl GateCount {
         println!("{:<15}{:>11}", "total:", self.total_gate_count());
         println!()
         //println!("nonfree:       {:?}\n", self.nonfree_gate_count()); //equals to and variants
+    }
+
+    pub fn and_count(&self) -> u64 {
+        self.0[GateType::And as usize]
+    }
+
+    pub fn nand_count(&self) -> u64 {
+        self.0[GateType::Nand as usize]
+    }
+
+    pub fn nimp_count(&self) -> u64 {
+        self.0[GateType::Nimp as usize]
+    }
+
+    pub fn imp_count(&self) -> u64 {
+        self.0[GateType::Imp as usize]
+    }
+
+    pub fn ncimp_count(&self) -> u64 {
+        self.0[GateType::Ncimp as usize]
+    }
+
+    pub fn cimp_count(&self) -> u64 {
+        self.0[GateType::Cimp as usize]
+    }
+
+    pub fn nor_count(&self) -> u64 {
+        self.0[GateType::Nor as usize]
+    }
+
+    pub fn or_count(&self) -> u64 {
+        self.0[GateType::Or as usize]
+    }
+
+    pub fn xor_count(&self) -> u64 {
+        self.0[GateType::Xor as usize]
+    }
+
+    pub fn xnor_count(&self) -> u64 {
+        self.0[GateType::Xnor as usize]
+    }
+
+    pub fn not_count(&self) -> u64 {
+        self.0[GateType::Not as usize]
     }
 }
 


### PR DESCRIPTION
tl;dr: Asked claude to make us a nice tracking of the gate number in the README

Implements continuous gate count monitoring for garbled circuit verification performance. The system automatically tracks total, non-free, and free gate counts, displaying them as dynamic badges in the README.

Key components:
- GitHub Actions workflow for automated gate counting on main branch pushes
- Example program to generate gate count metrics in JSON format
- Badge generation using shields.io endpoint format
- Deployment to 'gh-badges' branch for public badge hosting

This provides visibility into circuit complexity and helps track performance improvements over time.

https://github.com/cyphersnake/garbled-snark-verifier?tab=readme-ov-file#gate-count-metrics

![image](https://github.com/user-attachments/assets/724e1dd0-33b4-4a79-8833-f246dffe57e3)
