### PR TITLE
opt: reduce non-free gates by 60M using XOR-based arithmetization

### DIFF
--- a/circuit_component_macro/README.md
+++ b/circuit_component_macro/README.md
@@ -122,7 +122,7 @@ Examples:
 use circuit_component_macro::bn_component;
 
 #[bn_component(arity = "a.len() + 1")]
-fn add_generic(ctx: &mut impl CircuitContext, a: &BigIntWires, b: &BigIntWires) -> BigIntWires {
+fn add(ctx: &mut impl CircuitContext, a: &BigIntWires, b: &BigIntWires) -> BigIntWires {
     // ...
 }
 

--- a/src/core/gate/mod.rs
+++ b/src/core/gate/mod.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 
 pub use crate::GateType;
-use crate::{Delta, EvaluatedWire, GarbledWire, S, WireError, WireId};
+use crate::{
+    Delta, EvaluatedWire, GarbledWire, S, WireError, WireId, circuit::streaming::TRUE_WIRE,
+};
 pub mod garbling;
 use garbling::{Blake3Hasher, GateHasher, degarble, garble};
 
@@ -157,6 +159,16 @@ impl Gate {
             wire_b: wire_a,
             wire_c: wire_a,
             gate_type: GateType::Not,
+        }
+    }
+
+    #[must_use]
+    pub fn not_with_xor(wire_a: WireId, wire_c: WireId) -> Self {
+        Self {
+            wire_a,
+            wire_b: TRUE_WIRE,
+            wire_c,
+            gate_type: GateType::Xor,
         }
     }
 

--- a/src/gadgets/bigint/cmp.rs
+++ b/src/gadgets/bigint/cmp.rs
@@ -89,12 +89,8 @@ pub fn equal_zero<C: CircuitContext>(circuit: &mut C, a: &BigIntWires) -> WireId
     if a.len() == 1 {
         let is_bit_zero = circuit.issue_wire();
 
-        // Can't use `Gate::not` to input argument
-        circuit.add_gate(Gate::nand(
-            a.get(0).unwrap(),
-            a.get(0).unwrap(),
-            is_bit_zero,
-        ));
+        //this xor might be negated with innate NOT maintainence
+        circuit.add_gate(Gate::not_with_xor(a.get(0).unwrap(), is_bit_zero));
 
         return is_bit_zero;
     }
@@ -121,14 +117,14 @@ pub fn greater_than<C: CircuitContext>(
             .iter()
             .map(|b_i| {
                 let w = circuit.issue_wire();
-                // Can't use `Gate::not` to input argument
-                circuit.add_gate(Gate::nand(*b_i, *b_i, w));
+                //this xor might be negated with innate NOT maintainence
+                circuit.add_gate(Gate::not_with_xor(*b_i, w));
                 w
             })
             .collect(),
     };
 
-    let sum = super::add_generic(circuit, a, &not_b);
+    let sum = super::add(circuit, a, &not_b);
     sum.last().unwrap()
 }
 
@@ -143,8 +139,8 @@ pub fn less_than_constant<C: CircuitContext>(
             .iter()
             .map(|a_i| {
                 let w = circuit.issue_wire();
-                // Can't use `Gate::not` to input argument
-                circuit.add_gate(Gate::nand(*a_i, *a_i, w));
+                //this xor might be negated with innate NOT maintainence
+                circuit.add_gate(Gate::not_with_xor(*a_i, w));
                 w
             })
             .collect(),

--- a/src/gadgets/bn254/fp254impl.rs
+++ b/src/gadgets/bn254/fp254impl.rs
@@ -97,7 +97,7 @@ pub trait Fp254Impl {
         assert_eq!(a.len(), Self::N_BITS);
         assert_eq!(b.len(), Self::N_BITS);
 
-        let mut wires1 = bigint::add_generic(circuit, a, b);
+        let mut wires1 = bigint::add(circuit, a, b);
         let u = wires1.pop().unwrap();
 
         let mut wires2 = bigint::add_constant(circuit, &wires1, &Self::not_modulus_as_biguint());
@@ -325,9 +325,9 @@ pub trait Fp254Impl {
 
         let subtract_if_too_much = bigint::self_or_zero(circuit, &modulus_as_biguint, bound_check);
 
-        let new_sub = bigint::sub_generic_without_borrow(circuit, &sub, &subtract_if_too_much);
+        let new_sub = bigint::sub_without_borrow(circuit, &sub, &subtract_if_too_much);
 
-        bigint::sub_generic_without_borrow(circuit, &x_high, &new_sub)
+        bigint::sub_without_borrow(circuit, &x_high, &new_sub)
     }
 
     /// Modular inverse using extended Euclidean algorithm
@@ -462,7 +462,7 @@ pub trait Fp254Impl {
                         let k2 = bigint::add_constant_without_carry(circuit, &k, &BigUint::one());
 
                         // part3
-                        let u3 = bigint::sub_generic_without_borrow(circuit, &u1, &v2);
+                        let u3 = bigint::sub_without_borrow(circuit, &u1, &v2);
                         let v3 = v.clone();
                         let r3 = bigint::add_without_carry(circuit, &r, &s);
                         let s3 = bigint::double_without_overflow(circuit, &s);
@@ -470,7 +470,7 @@ pub trait Fp254Impl {
 
                         // part4
                         let u4 = u.clone();
-                        let v4 = bigint::sub_generic_without_borrow(circuit, &v2, &u1);
+                        let v4 = bigint::sub_without_borrow(circuit, &v2, &u1);
                         let r4 = bigint::double_without_overflow(circuit, &r);
                         let s4 = bigint::add_without_carry(circuit, &r, &s);
                         let k4 = bigint::add_constant_without_carry(circuit, &k, &BigUint::one());


### PR DESCRIPTION
Contributes to fixing #32 and removes unnecessary `generic` suffix from arithmetic functions for clarity. 