### PR TITLE
Fix Gate Count Mismatch

### DIFF
--- a/src/gadgets/bn254/fp254impl.rs
+++ b/src/gadgets/bn254/fp254impl.rs
@@ -386,7 +386,7 @@ pub trait Fp254Impl {
 
         // initialize value for wires
         let neg_odd_part = Self::neg(circuit, &odd_part);
-        let u = Self::half(circuit, &neg_odd_part);
+        let u = bigint::half(circuit, &neg_odd_part);
         let v = odd_part;
 
         let k = BigIntWires::new_constant(a.len(), &BigUint::from(ark_bn254::Fq::ONE)).unwrap();

--- a/src/gadgets/bn254/mod.rs
+++ b/src/gadgets/bn254/mod.rs
@@ -14,8 +14,6 @@ pub mod g1;
 pub mod g2;
 pub mod montgomery;
 pub mod pairing;
-
-pub use final_exponentiation::final_exponentiation;
 pub use fp254impl::Fp254Impl;
 pub use fq::Fq;
 //pub use fq2::Fq2;

--- a/src/gadgets/bn254/pairing.rs
+++ b/src/gadgets/bn254/pairing.rs
@@ -22,7 +22,7 @@ use crate::{
     CircuitContext, Fp254Impl,
     circuit::streaming::{FromWires, OffCircuitParam, WiresArity, WiresObject},
     gadgets::bn254::{
-        final_exponentiation::final_exponentiation, fq::Fq, fq2::Fq2, fq6::Fq6, fq12::Fq12,
+        final_exponentiation::final_exponentiation_montgomery, fq::Fq, fq2::Fq2, fq6::Fq6, fq12::Fq12,
         g1::G1Projective, g2::G2Projective,
     },
 };
@@ -885,7 +885,7 @@ pub fn pairing_const_q<C: CircuitContext>(
     q: &ark_bn254::G2Affine,
 ) -> Fq12 {
     let f = miller_loop_const_q(circuit, p, q);
-    final_exponentiation(circuit, &f)
+    final_exponentiation_montgomery(circuit, &f)
 }
 
 /// Multi-pairing aggregation with constant `Q_i` and variable `P_i`.
@@ -896,7 +896,7 @@ pub fn multi_pairing_const_q<C: CircuitContext>(
     qs: &[ark_bn254::G2Affine],
 ) -> Fq12 {
     let f = multi_miller_loop_const_q(circuit, ps, qs);
-    final_exponentiation(circuit, &f)
+    final_exponentiation_montgomery(circuit, &f)
 }
 
 impl OffCircuitParam for &ark_bn254::Fq6 {
@@ -1024,7 +1024,7 @@ mod tests {
         },
         gadgets::{
             bigint::{BigUint as BigUintOutput, bits_from_biguint_with_len},
-            bn254::{final_exponentiation, fp254impl::Fp254Impl, g2::G2Projective as G2Wires},
+            bn254::{fp254impl::Fp254Impl, g2::G2Projective as G2Wires},
         },
     };
 
@@ -1791,7 +1791,7 @@ mod tests {
         let result = CircuitBuilder::streaming_execute::<_, _, FinalExpOutput>(
             input,
             10_000,
-            |ctx, input| final_exponentiation(ctx, &input.f),
+            |ctx, input| final_exponentiation_montgomery(ctx, &input.f),
         );
 
         assert_eq!(result.output_value.value, expected_m);
@@ -1882,7 +1882,7 @@ mod tests {
             10_000,
             |ctx, input| {
                 let f_ml = miller_loop_montgomery_fast(ctx, &input.p, &input.q);
-                final_exponentiation(ctx, &f_ml)
+                final_exponentiation_montgomery(ctx, &f_ml)
             },
         );
 


### PR DESCRIPTION
This PR will fix the gate count mismatch between v0.1 and v0.2. Closes #32 

Found and fixed issues in this PR:
- final_exponentation() function is a mix of montgomery and non-montgomery functions, there is a correct version already, final_exponentation_montgomery. I removed the wrong one, and used the correct one in necessary places.
- cyclotomic_exp_fast_inverse_montgomery_fast function needs to call cyclotomic_square in the loop, because it is better version of square that can be used if the input is in a certain subgroup. This was the main reason for the gate count mismatch.
- fix wrong usage of Self in Fp254impl::inverse, use bigint instead.