### PR TITLE
perf: remove `gate_id` from garble table

### DIFF
--- a/examples/groth16_cut_and_choose.rs
+++ b/examples/groth16_cut_and_choose.rs
@@ -276,7 +276,7 @@ fn run_evaluator(
     let mut senders = Vec::with_capacity(finalize);
 
     let eval = ccn::Evaluator::create(&mut rng, cfg.clone(), commits, &mut |index| {
-        let (tx, rx) = channel::unbounded::<(usize, S)>();
+        let (tx, rx) = channel::unbounded::<S>();
         senders.push((index, tx));
         rx
     });

--- a/examples/groth16_garble.rs
+++ b/examples/groth16_garble.rs
@@ -201,8 +201,8 @@ fn run_with_hasher<H: GateHasher + 'static>(garbling_seed: u64) {
         let calculated_ciphertext_hash = std::thread::spawn(move || {
             let mut hasher = CiphertextHashAcc::default();
 
-            while let Ok((index, ciphertext)) = ciphertext_to_evaluator_receiver.recv() {
-                proxy_sender.send((index, ciphertext)).unwrap();
+            while let Ok(ciphertext) = ciphertext_to_evaluator_receiver.recv() {
+                proxy_sender.send(ciphertext).unwrap();
                 hasher.update(ciphertext);
             }
 

--- a/src/circuit/garble_evaluate_integration_test.rs
+++ b/src/circuit/garble_evaluate_integration_test.rs
@@ -28,8 +28,8 @@ use crate::{
 };
 
 // Define the types locally since they're not exported
-type GarbledTableEntry = (usize, S);
-type CiphertextEntry = (usize, S);
+type GarbledTableEntry = S;
+type CiphertextEntry = S;
 
 /// Test inputs that work for both garbling and evaluation
 #[derive(Debug)]
@@ -216,8 +216,8 @@ fn test_garble_evaluate_connection() {
 
     // Convert garbled tables to ciphertext entries
     // In a real scenario, these would come from the garbler
-    for (gate_id, ciphertext) in &garbled_tables {
-        let ciphertext_entry: CiphertextEntry = (*gate_id, *ciphertext);
+    for ciphertext in &garbled_tables {
+        let ciphertext_entry: CiphertextEntry = *ciphertext;
         if eval_sender.send(ciphertext_entry).is_err() {
             break;
         }
@@ -366,8 +366,8 @@ fn test_multiple_input_combinations() {
         // Evaluation setup
         println!("\n--- EVALUATION SETUP ---");
         let (eval_sender, eval_receiver) = channel::unbounded();
-        for (gate_id, ciphertext) in garbled_tables {
-            let ciphertext_entry: CiphertextEntry = (gate_id, ciphertext);
+        for ciphertext in garbled_tables {
+            let ciphertext_entry: CiphertextEntry = ciphertext;
             if eval_sender.send(ciphertext_entry).is_err() {
                 break;
             }

--- a/src/circuit/garble_integration_test.rs
+++ b/src/circuit/garble_integration_test.rs
@@ -82,9 +82,6 @@ mod tests {
         // Verify the circuit was garbled correctly
         // Only the AND gate should produce a table entry (XOR uses Free-XOR)
         assert_eq!(tables.len(), 1, "Only AND gate should produce table");
-
-        // The table entry should be from the AND gate (gate_id 0)
-        assert_eq!(tables[0].0, 0, "First table entry should be from gate 0");
     }
 
     #[test]

--- a/src/circuit/modes/evaluate_mode/evaluate_test.rs
+++ b/src/circuit/modes/evaluate_mode/evaluate_test.rs
@@ -139,8 +139,7 @@ fn test_evaluate_mode() {
         let mut rng = ChaChaRng::seed_from_u64(1);
         iter::repeat_with(move || S::random(&mut rng))
             .take(NON_FREE_GATE_COUNT)
-            .enumerate()
-            .for_each(|(i, ct)| sender.send((i, ct)).unwrap());
+            .for_each(|ct| sender.send(ct).unwrap());
     });
 
     let (true_wire, false_wire, inputs) = prepare();

--- a/src/circuit/modes/garble_mode.rs
+++ b/src/circuit/modes/garble_mode.rs
@@ -59,7 +59,7 @@ impl Default for GarbledWire {
 }
 
 /// Output type for garbled tables - only actual ciphertexts
-pub type GarbledTableEntry = (usize, S);
+pub type GarbledTableEntry = S;
 
 /// Garble mode - generates garbled circuits with streaming output
 pub struct GarbleMode<H: hashers::GateHasher, CTH: CiphertextHandler> {
@@ -123,11 +123,11 @@ impl<H: hashers::GateHasher, CTH: CiphertextHandler> GarbleMode<H, CTH> {
         index
     }
 
-    fn stream_table_entry(&mut self, gate_id: usize, entry: Option<S>) {
+    fn stream_table_entry(&mut self, _gate_id: usize, entry: Option<S>) {
         let Some(ciphertext) = entry else {
             return;
         };
-        self.output_handler.handle(gate_id, ciphertext);
+        self.output_handler.handle(ciphertext);
     }
 }
 

--- a/tests/streaming_evaluate.rs
+++ b/tests/streaming_evaluate.rs
@@ -417,12 +417,12 @@ fn test_bn254_fq_complex_chain_garble_eval() {
             g_sender,
             fq_complex_circuit,
         );
-    let tables: Vec<(usize, S)> = g_receiver.try_iter().collect();
+    let tables: Vec<S> = g_receiver.try_iter().collect();
 
     // Forward ciphertexts to evaluator
     let (e_sender, e_receiver) = channel::unbounded();
-    for (i, ct) in tables {
-        let _ = e_sender.send((i, ct));
+    for ct in tables {
+        let _ = e_sender.send(ct);
     }
     drop(e_sender);
 


### PR DESCRIPTION
At the time of debugging, the GateId, Ciphertext pair was used everywhere for the ciphertext.

Now that the full float is working, it can be reduced to a single ciphertext for efficiency, since the circuit topology is common to all parties