### PR TITLE
perf: migrate vsss from k256 to arkworks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-secp256k1"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bd211c48debd3037b48873a7aa22c3aba034e83388aa4124795c9f220b88c7"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +931,7 @@ dependencies = [
  "ark-ff",
  "ark-groth16",
  "ark-relations",
+ "ark-secp256k1",
  "ark-serialize",
  "ark-snark",
  "ark-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,9 @@ thiserror = "2.0.12"
 serde_json = "1.0"
 serde = { version = "1.0.225", features = ["derive"] }
 ark-serialize = "0.5.0"
+ark-secp256k1 = "0.5.0"
 
 bitcoin = { version = "0.32.7", features = ["rand", "rand-std"] }
-k256 = "0.13.4"
 sha2 = "0.10.9"
 
 [dev-dependencies]
@@ -63,6 +63,7 @@ serde_json = "1.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 bitvm = { git = "https://github.com/BitVM/BitVM", branch = "main" }
+k256 = "0.13.4"
 
 # Install Git hooks via cargo-husky
 [dev-dependencies.cargo-husky]

--- a/src/cac/vsss.rs
+++ b/src/cac/vsss.rs
@@ -1,125 +1,124 @@
-use k256::elliptic_curve::PrimeField;
-use k256::{ProjectivePoint, Scalar};
-use rand;
-use std::ops::Add;
-use std::ops::Mul;
+use std::ops::{Add, Mul};
+
+use ark_ec::PrimeGroup;
+use ark_ff::{Field, One, UniformRand, Zero};
+use ark_secp256k1::{Fr, Projective};
+use rand::Rng;
 
 // we use this for both polynomials over scalars and over projective points
 pub struct Polynomial<T>(Vec<T>);
 
 impl<T> Polynomial<T>
 where
-    T: Add<T, Output = T> + Mul<Scalar, Output = T> + Copy,
+    for<'a> T: Add<T, Output = T> + Mul<&'a Fr, Output = T> + Clone,
 {
     // todo: max x an int
-    fn eval_at(&self, x: Scalar) -> T {
-        self.0
-            .iter()
-            .skip(1)
-            .fold((self.0[0], Scalar::ONE), |(acc, prev_factor), &elem| {
-                let new_factor = prev_factor * x;
-                (acc + elem * new_factor, new_factor)
-            })
-            .0
+    fn eval_at(&self, x: Fr) -> T {
+        // Horner's method
+        let mut iter = self.0.iter().rev();
+        let mut acc = iter
+            .next()
+            .expect("polynomial must have at least one coefficient")
+            .clone();
+        for coeff in iter {
+            acc = coeff.clone() + acc * &x;
+        }
+        acc
     }
 }
 
-impl Polynomial<Scalar> {
-    pub fn rand(degree: usize) -> Self {
-        Self(
-            (0..degree + 1)
-                .map(|_| Scalar::generate_vartime(&mut rand::thread_rng()))
-                .collect(),
-        )
+impl Polynomial<Fr> {
+    pub fn rand(mut rand: impl Rng, degree: usize) -> Self {
+        Self((0..degree + 1).map(|_| Fr::rand(&mut rand)).collect())
     }
+
     pub fn coefficient_commits(&self) -> PolynomialCommits {
-        PolynomialCommits(Polynomial(
-            self.0
-                .iter()
-                .map(|x| ProjectivePoint::GENERATOR * x)
-                .collect(),
-        ))
+        let generator = Projective::generator();
+        PolynomialCommits(Polynomial(self.0.iter().map(|x| generator * x).collect()))
     }
+
     // shares are return with 0-based index. However, we evaluate share i at
     // x = i+1, since the value at x=0 represents the secret
-    pub fn shares(&self, num_shares: usize) -> Vec<(usize, Scalar)> {
+    pub fn shares(&self, num_shares: usize) -> Vec<(usize, Fr)> {
         (0..num_shares)
-            .map(|i| (i, self.eval_at(Scalar::from_u128((i + 1) as u128))))
-            .collect::<Vec<_>>()
+            .map(|i| (i, self.eval_at(Fr::from((i + 1) as u64))))
+            .collect()
     }
+
     pub fn share_commits(&self, num_shares: usize) -> ShareCommits {
         ShareCommits(
             self.shares(num_shares)
                 .into_iter()
-                .map(|(_, share)| ProjectivePoint::GENERATOR * share)
+                .map(|(_, share)| Projective::generator() * share)
                 .collect(),
         )
     }
 }
 
-pub struct PolynomialCommits(Polynomial<ProjectivePoint>);
+pub struct PolynomialCommits(Polynomial<Projective>);
 
-pub struct ShareCommits(pub Vec<ProjectivePoint>);
+pub struct ShareCommits(pub Vec<Projective>);
+
 impl ShareCommits {
     pub fn verify(&self, polynomial_commits: &PolynomialCommits) -> Result<(), String> {
         for (i, share_commit) in self.0.iter().enumerate() {
-            let recomputed_share_commit = polynomial_commits
-                .0
-                .eval_at(Scalar::from_u128((i + 1) as u128));
+            let recomputed_share_commit = polynomial_commits.0.eval_at(Fr::from((i + 1) as u64));
+
             if share_commit != &recomputed_share_commit {
-                return Err("Share commit verification failed".to_string());
+                return Err("Share commit verification failed".to_owned());
             }
         }
         Ok(())
     }
 
-    pub fn verify_shares(&self, shares: &[(usize, Scalar)]) -> Result<(), String> {
+    pub fn verify_shares(&self, shares: &[(usize, Fr)]) -> Result<(), String> {
         let mut indices = shares.iter().map(|(i, _)| *i).collect::<Vec<_>>();
         indices.sort_unstable();
         if indices.windows(2).any(|arr| arr[0] == arr[1]) {
-            return Err("Duplicate share index found".to_string());
+            return Err("Duplicate share index found".to_owned());
         }
 
         for (i, share) in shares.iter() {
             let share_commit = self
                 .0
                 .get(*i)
-                .ok_or("Share index out of bounds".to_string())?;
+                .ok_or("Share index out of bounds".to_owned())?;
 
-            if *share_commit != ProjectivePoint::GENERATOR * share {
-                return Err("Share verification failed".to_string());
+            if *share_commit != Projective::generator() * share {
+                return Err("Share verification failed".to_owned());
             }
         }
+
         Ok(())
     }
 }
 
 // find the missing point by using the Lagrange interpolation, see https://en.wikipedia.org/wiki/Lagrange_polynomial
 // Input is a vec of (index, value), where index is 0-based
-pub fn lagrange_interpolate_at_index(points: &[(usize, Scalar)], index: usize) -> Scalar {
-    lagrange_interpolate_at_x(points, Scalar::from_u128((index + 1) as u128))
+pub fn lagrange_interpolate_at_index(points: &[(usize, Fr)], index: usize) -> Fr {
+    lagrange_interpolate_at_x(points, Fr::from((index + 1) as u64))
 }
 
 // internal function that allows also queying g(0)
-fn lagrange_interpolate_at_x(points: &[(usize, Scalar)], x: Scalar) -> Scalar {
-    let scalar = |val: usize| Scalar::from_u128(val as u128);
+fn lagrange_interpolate_at_x(points: &[(usize, Fr)], x: Fr) -> Fr {
+    let sc = |val: usize| Fr::from(val as u64);
     points
         .iter()
         .enumerate()
-        .fold(Scalar::ZERO, |result, (i, (idx, y_i))| {
-            let x_i = scalar(*idx + 1); // share 0 corresponds to x=1
+        .fold(Fr::zero(), |result, (i, (idx, y_i))| {
+            let x_i = sc(*idx + 1); // share 0 corresponds to x=1
             // Compute L_i(x)
             let (num, denum) = points.iter().enumerate().filter(|(j, _)| *j != i).fold(
-                (Scalar::ONE, Scalar::ONE),
+                (Fr::one(), Fr::one()),
                 |(num, denum), (_, (idx, _))| {
-                    let x_j = scalar(*idx + 1); // share 0 corresponds to x=1
+                    let x_j = sc(*idx + 1); // share 0 corresponds to x=1
 
                     (num * (x - x_j), denum * (x_i - x_j))
                 },
             );
 
             // calculate li = num / denum = num * denum^{-1}
-            let denum_inv = denum.invert().expect("x_i - x_j must be nonzero");
+            let denum_inv = denum.inverse().expect("x_i - x_j must be nonzero");
             let li = num * denum_inv;
 
             result + *y_i * li
@@ -132,10 +131,11 @@ mod tests {
 
     #[test]
     fn test_polynomial_eval() {
-        let polynomial = Polynomial::<Scalar>::rand(2);
+        let polynomial = Polynomial::<Fr>::rand(rand::thread_rng(), 2);
+
         match polynomial.0.as_slice() {
             &[a, b, c] => {
-                let x = Scalar::generate_vartime(&mut rand::thread_rng());
+                let x = Fr::rand(&mut rand::thread_rng());
                 assert_eq!(polynomial.eval_at(x), a + b * x + c * x * x);
             }
             _ => unreachable!(),
@@ -145,12 +145,12 @@ mod tests {
     #[test]
     fn test_interpolation_from_coefficients() {
         let polynomial_degree = 3;
-        let polynomial = Polynomial::rand(polynomial_degree);
+        let polynomial = Polynomial::rand(rand::thread_rng(), polynomial_degree);
 
         let num_shares = polynomial_degree + 1;
         let points = polynomial.shares(num_shares);
 
-        let secret = lagrange_interpolate_at_x(&points, Scalar::ZERO);
+        let secret = lagrange_interpolate_at_x(&points, Fr::zero());
 
         assert_eq!(secret, polynomial.0[0]);
     }
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn test_interpolate_missing_shares() {
         let polynomial_degree = 3;
-        let polynomial = Polynomial::rand(polynomial_degree);
+        let polynomial = Polynomial::rand(rand::thread_rng(), polynomial_degree);
         let points = polynomial.shares(6);
         let selected_points = &points[..polynomial_degree + 1];
         let missing_points = &points[polynomial_degree + 1..];
@@ -172,12 +172,15 @@ mod tests {
     #[test]
     fn test_commit_verification() {
         let polynomial_degree = 3;
-        let polynomial = Polynomial::rand(polynomial_degree);
+        let polynomial = Polynomial::rand(rand::thread_rng(), polynomial_degree);
 
         let num_shares = polynomial_degree + 1;
-
-        let polynomial_commits = polynomial.coefficient_commits();
+        let poly_commits = polynomial.coefficient_commits();
         let share_commits = polynomial.share_commits(num_shares);
-        share_commits.verify(&polynomial_commits).unwrap();
+
+        share_commits.verify(&poly_commits).unwrap();
+
+        let shares = polynomial.shares(num_shares);
+        share_commits.verify_shares(&shares).unwrap();
     }
 }


### PR DESCRIPTION
- port the verifiable secret sharing implementation onto arkworks
- `cac::tests::test_full_flow` runtime dropped 1.591s -> 0.162s (~9.8x faster)
- move bitcoin staff into tests-only deps