### PR TITLE
fix(c&c): adding `serde::*` for all types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "garbled-snark-verifier"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "ark-bn254",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "garbled-snark-verifier"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["BitVM Alliance"]
 license = "GPL-3.0-only"

--- a/src/cac/adaptor_sigs.rs
+++ b/src/cac/adaptor_sigs.rs
@@ -27,6 +27,7 @@ fn is_odd(y: &Fq) -> bool {
     y.into_bigint().is_odd()
 }
 
+#[derive(Clone, Debug)]
 pub struct AdaptorInfo {
     garbler_commit: Projective,
     evaluator_nonce_commit: Projective,

--- a/src/cac/vsss.rs
+++ b/src/cac/vsss.rs
@@ -4,8 +4,10 @@ use ark_ec::PrimeGroup;
 use ark_ff::{Field, One, UniformRand, Zero};
 use ark_secp256k1::{Fr, Projective};
 use rand::Rng;
+use serde::{Deserialize, Serialize};
 
 // we use this for both polynomials over scalars and over projective points
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Polynomial<T>(Vec<T>);
 
 impl<T> Polynomial<T>
@@ -55,8 +57,10 @@ impl Polynomial<Fr> {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct PolynomialCommits(Polynomial<Projective>);
 
+#[derive(Clone, Debug)]
 pub struct ShareCommits(pub Vec<Projective>);
 
 impl ShareCommits {

--- a/src/circuit/modes/evaluate_mode.rs
+++ b/src/circuit/modes/evaluate_mode.rs
@@ -1,5 +1,7 @@
 use std::num::NonZero;
 
+use serde::{Deserialize, Serialize};
+
 use super::garble_mode::{GarbledWire, halfgates_garbling};
 use crate::{
     Gate, S, WireId,
@@ -9,7 +11,7 @@ use crate::{
     storage::{Credits, Storage},
 };
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EvaluatedWire {
     pub active_label: S,
     pub value: bool,

--- a/src/cut_and_choose/evaluator.rs
+++ b/src/cut_and_choose/evaluator.rs
@@ -169,6 +169,7 @@ where
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EvaluatorCaseInput<I> {
     pub index: usize,
     pub input: I,

--- a/src/cut_and_choose/garbler.rs
+++ b/src/cut_and_choose/garbler.rs
@@ -17,7 +17,7 @@ use crate::{
     cut_and_choose::{Commit, Config, Seed, commit_label},
 };
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GarbledInstance {
     /// Constant to represent false wire constant
     ///
@@ -127,7 +127,7 @@ pub enum OpenForInstance {
     },
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum GarblerStage {
     Generating { seeds: Box<[Seed]> },
     PreparedForEval { indexes_to_eval: Box<[usize]> },
@@ -148,7 +148,7 @@ impl GarblerStage {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Garbler<I: CircuitInput + Clone> {
     stage: GarblerStage,
     instances: Vec<GarbledInstance>,

--- a/src/cut_and_choose/groth16.rs
+++ b/src/cut_and_choose/groth16.rs
@@ -18,6 +18,7 @@ pub const DEFAULT_CAPACITY: usize = 150_000;
 
 /// Groth16-specific wrapper preserving the existing API while delegating
 /// to the generic cut-and-choose implementation.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Garbler {
     inner: generic::Garbler<garbled_groth16::GarblerCompressedInput>,
 }

--- a/src/garbled_groth16.rs
+++ b/src/garbled_groth16.rs
@@ -168,7 +168,7 @@ impl<H: GateHasher, CTH: CiphertextHandler> EncodeInput<GarbleMode<H, CTH>> for 
 // ============================================================================
 
 /// Bit-vector wrapper for field element wires evaluated against garbled labels.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvaluatedFrWires(pub Vec<EvaluatedWire>);
 
 impl Deref for EvaluatedFrWires {
@@ -481,23 +481,25 @@ impl<H: GateHasher, CTH: CiphertextHandler> EncodeInput<GarbleMode<H, CTH>>
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvaluatedCompressedG1Wires {
     pub x: EvaluatedFrWires,
     pub y_flag: EvaluatedWire,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvaluatedCompressedG2Wires {
     pub x: [EvaluatedFrWires; 2],
     pub y_flag: EvaluatedWire,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvaluatorCompressedInput {
     pub public: Vec<EvaluatedFrWires>,
     pub a: EvaluatedCompressedG1Wires,
     pub b: EvaluatedCompressedG2Wires,
     pub c: EvaluatedCompressedG1Wires,
+    #[serde(with = "ark_canonical")]
     pub vk: VerifyingKey<Bn254>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub mod ark {
         lc,
         r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
     };
+    pub use ark_serialize;
     pub use ark_snark::{CircuitSpecificSetupSNARK, SNARK};
 }
 


### PR DESCRIPTION
In case you are doing a full C&C with intermediate state preservation you need all types to serialize and deserialize, this PR fixes the flaw that some types didn't do that