### PR TITLE
feat: batched generator mul with precomputed tables

### DIFF
--- a/src/cac/mod.rs
+++ b/src/cac/mod.rs
@@ -18,16 +18,18 @@ mod tests {
         let n = 181;
         let k = 181 - 7;
 
+        let secp = vsss::Secp256k1::new();
+
         let mut rng = rand::thread_rng();
 
         // step 1: garbler generates secret:
         let polynomial = vsss::Polynomial::rand(&mut rng, k);
 
         // step 2: garbler send commitments to the polynomial coefficients to the evaluator
-        let coefficient_commits = polynomial.coefficient_commits();
+        let coefficient_commits = polynomial.coefficient_commits(&secp);
 
         // step 3: garbler shares commits, sends them to evaluator
-        let share_commits = polynomial.share_commits(n);
+        let share_commits = polynomial.share_commits(&secp, n);
 
         // step 4: evaluator verifies correctness of the share commits:
         share_commits
@@ -46,7 +48,7 @@ mod tests {
 
         // step 7: evaluator checks that the selected shares match the share commits
         share_commits
-            .verify_shares(&selected_shares)
+            .verify_shares(&secp, &selected_shares)
             .expect("Share verification failed");
 
         // step 8: (omitted) evaluator checks the garbled circuit validity


### PR DESCRIPTION
Reduces execution of steps 1-10 of the test (which is the part that gets run during cac) by 36%. It reduces the polynomial multiplications with the generator in `coefficient_commits`, `share_commits` and `verify_shares` from ~18 ms to ~2ms. Steps 1-10 now take ~0.1 second on my machine. The precomputed multiplication table is about 4 MB in size and it takes about 7 ms to calculate.

This uses precomputed tables for the multiplications with the generator. I ended up not using their `batch_mul` directly, because (1) it needlessly converts the points to affine points, and (2) it uses rayon to parallelize the multiplications. In principle this parallelization is great, but:
- we would no longer be able to assume that we can expect a linear speedup by parallelizing the work for each input label
- it messes up the flamegraph - code executed by rayon doesn't preserve the callstack, so it's really hard to see how long everything takes

It should be noted that the parallelization inside ark-ec is an optional feature. However, the feature is automatically selected by other dependencies that we have, so we can't easily disable it.

As can be seen below, execution time is now dominated by the msm calculation in `ShareCommits::verify`. I see some small optimizations that can be done for maybe a 2% speedup, but it seems like at this point what's needed is msm optimization.

<img width="3816" height="627" alt="image" src="https://github.com/user-attachments/assets/0f2cc9cb-b01a-4515-916f-f9f5a39230c0" />
