### PR TITLE
opt: change polynomials to point value form

### DIFF
--- a/src/cac/mod.rs
+++ b/src/cac/mod.rs
@@ -1,4 +1,5 @@
 pub mod adaptor_sigs;
+pub mod utils;
 pub mod vsss;
 
 #[cfg(test)]

--- a/src/cac/mod.rs
+++ b/src/cac/mod.rs
@@ -11,7 +11,7 @@ mod tests {
     use sha2::{Digest, Sha256};
 
     use super::*;
-    use crate::cac::{adaptor_sigs::AdaptorInfo, vsss::lagrange_interpolate_at_index};
+    use crate::cac::{adaptor_sigs::AdaptorInfo, vsss::lagrange_interpolate_whole_polynomial};
 
     #[test]
     fn test_full_flow() {
@@ -103,13 +103,16 @@ mod tests {
             &[(unused_share_commit.0, unused_share_secret)],
         ]
         .concat();
-        let missing_shares = (0..n)
-            .filter(|&i| combined_shares.iter().all(|(j, _)| i != *j))
-            .map(|i| (i, lagrange_interpolate_at_index(&combined_shares, i)))
-            .collect::<Vec<_>>();
 
-        for share in missing_shares {
-            assert_eq!(share, all_shares[share.0]);
+        let missing_points: Vec<usize> = (0..n)
+            .filter(|&i| combined_shares.iter().all(|(j, _)| i != *j))
+            .collect();
+
+        let missing_shares =
+            lagrange_interpolate_whole_polynomial(&combined_shares, &missing_points);
+
+        for (x, y) in missing_points.into_iter().zip(missing_shares.into_iter()) {
+            assert_eq!(all_shares[x].1, y)
         }
     }
 }

--- a/src/cac/utils.rs
+++ b/src/cac/utils.rs
@@ -1,0 +1,27 @@
+/// Returns the representation of number with given le bits as minimum number of additions/subtractions with powers of two
+pub fn neg_pos_sum_of_powers_of_two(bits: Vec<bool>) -> Vec<i8> {
+    let mut len = bits.len();
+    let mut res = vec![0i8; len + 1];
+    let mut l: i32 = -1;
+    for i in 0..len {
+        if !bits[i] {
+            l = -1;
+        } else if i == len - 1 || !bits[i + 1] {
+            if l == -1 {
+                res[i] = 1;
+            } else {
+                res[i + 1] = 1;
+                res[l as usize] = -1;
+            }
+        } else if l == -1 {
+            l = i as i32;
+        }
+    }
+
+    while len > 0 && res[len] == 0 {
+        res.pop();
+        len -= 1;
+    }
+
+    res
+}

--- a/src/cac/vsss.rs
+++ b/src/cac/vsss.rs
@@ -57,30 +57,125 @@ impl Secp256k1 {
     }
 }
 
-// we use this for both polynomials over scalars and over projective points
+fn precalculated_factorials_and_inverses(n: usize) -> (Vec<Fr>, Vec<Fr>, Vec<Fr>) {
+    let factorial: Vec<Fr> = std::iter::once(Fr::one())
+        .chain((1..n).scan(Fr::one(), |state, i| {
+            *state *= Fr::from(i as u64);
+            Some(*state)
+        }))
+        .collect();
+
+    // inv_fact[i] = 1 / factorial[i]
+    let inv_factorial: Vec<Fr> = (0..n)
+        .rev()
+        .scan(
+            factorial[n - 1]
+                .inverse()
+                .expect("This is guaranteed to be non-zero"),
+            |cur_state, i| {
+                let ith_value = *cur_state;
+                *cur_state *= Fr::from(i as u64);
+                Some(ith_value)
+            },
+        )
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+
+    let inv: Vec<Fr> = (0..n)
+        .map(|i| {
+            if i == 0 {
+                Fr::zero() //This should never be used
+            } else {
+                inv_factorial[i] * factorial[i - 1]
+            }
+        })
+        .collect();
+
+    (factorial, inv_factorial, inv)
+}
+
+// This polynomial is in the (point, value) form instead of coefficient form (points are integers in range [0, degree] converted to Fr's)
+// It's used both for polynomials with scalar and projective point domains
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Polynomial<T>(Vec<T>);
 
 impl<T> Polynomial<T>
 where
-    for<'a> T: Add<T, Output = T> + Mul<&'a Fr, Output = T> + Clone,
+    for<'a> T: Add<T, Output = T> + Mul<&'a Fr, Output = T> + Clone + Zero,
 {
-    // todo: max x an int
-    fn eval_at(&self, x: Fr) -> T {
-        // Horner's method
-        let mut iter = self.0.iter().rev();
-        let mut acc = iter
-            .next()
-            .expect("polynomial must have at least one coefficient")
-            .clone();
-        for coeff in iter {
-            acc = coeff.clone() + acc * &x;
+    #[allow(dead_code)]
+    // naive lagrange interpolation, used for testing
+    fn eval_at(&self, x: usize) -> T {
+        if x < self.0.len() {
+            return self.0[x].clone();
         }
-        acc
+
+        let x_fr = Fr::from(x as u32);
+        self.0
+            .iter()
+            .enumerate()
+            .fold(T::zero(), |result, (i, y_i)| {
+                let x_i = Fr::from(i as u64);
+                // Compute L_i(x)
+                let (num, denum) = self.0.iter().enumerate().filter(|(j, _)| *j != i).fold(
+                    (Fr::one(), Fr::one()),
+                    |(num, denum), (j, _)| {
+                        let x_j = Fr::from(j as u64);
+                        (num * (x_fr - x_j), denum * (x_i - x_j))
+                    },
+                );
+
+                // calculate li = num / denum = num * denum^{-1}
+                let denum_inv = denum.inverse().expect("x_i - x_j must be nonzero");
+                let li = num * denum_inv;
+
+                result + y_i.clone() * &li
+            })
+    }
+
+    /// evaluates the function at smallest consecutive integer points bigger than the degree
+    /// functions similar to [`lagrange_interpolate_whole_polynomial`],
+    fn eval_at_suffix_points(&self, n_points: usize) -> Vec<T> {
+        let n_known = self.0.len();
+        let n = n_known + n_points;
+        let (factorial, inv_factorial, inv) = precalculated_factorials_and_inverses(n);
+
+        // For x, calculates the multiplication of (x - i) for all i in known_points (known_points = 0..=degree)
+        // returns the inverse of the multiplication result, if its one of the known points
+        let get_coeff = |x: usize| {
+            if x < n_known {
+                //inverse
+                let mut result = inv_factorial[x] * inv_factorial[n_known - 1 - x];
+                if (n_known - x).is_multiple_of(2) {
+                    result *= -Fr::one();
+                }
+                result
+            } else {
+                factorial[x] * inv_factorial[x - n_known]
+            }
+        };
+
+        let lagrange_basis_polynomial_coeffs: Vec<Fr> = (0..n_known).map(&get_coeff).collect();
+
+        (n_known..n_known + n_points)
+            .map(|x| {
+                let mut result = T::zero();
+                let nom_coeff = get_coeff(x);
+                for i in 0..n_known {
+                    let whole_coeff: Fr =
+                        lagrange_basis_polynomial_coeffs[i] * inv[x - i] * nom_coeff;
+                    result = result + self.0[i].clone() * &whole_coeff;
+                }
+                result
+            })
+            .collect()
     }
 }
 
 impl Polynomial<Fr> {
+    // Generate with points with Fr coordinates in the range [0, degree] for efficient commitment
     pub fn rand(mut rand: impl Rng, degree: usize) -> Self {
         Self((0..degree + 1).map(|_| Fr::rand(&mut rand)).collect())
     }
@@ -89,11 +184,17 @@ impl Polynomial<Fr> {
         PolynomialCommits(Polynomial(secp.generator_batch_mul(&self.0)))
     }
 
-    // shares are return with 0-based index. However, we evaluate share i at
-    // x = i+1, since the value at x=0 represents the secret
     pub fn shares(&self, num_shares: usize) -> Vec<(usize, Fr)> {
+        let n_known = self.0.len();
+        let suffix_points = self.eval_at_suffix_points(num_shares - n_known);
         (0..num_shares)
-            .map(|i| (i, self.eval_at(Fr::from((i + 1) as u64))))
+            .map(|i| {
+                if i < n_known {
+                    (i, self.0[i])
+                } else {
+                    (i, suffix_points[i - n_known])
+                }
+            })
             .collect()
     }
 
@@ -116,9 +217,15 @@ pub struct ShareCommits(pub Vec<Projective>);
 
 impl ShareCommits {
     pub fn verify(&self, polynomial_commits: &PolynomialCommits) -> Result<(), String> {
+        let n_known = polynomial_commits.0.0.len();
+        let n_unknown = self.0.len() - n_known;
+        let unknown_points = polynomial_commits.0.eval_at_suffix_points(n_unknown);
         for (i, share_commit) in self.0.iter().enumerate() {
-            let recomputed_share_commit = polynomial_commits.0.eval_at(Fr::from((i + 1) as u64));
-
+            let recomputed_share_commit = if i < n_known {
+                polynomial_commits.0.0[i]
+            } else {
+                unknown_points[i - n_known]
+            };
             if share_commit != &recomputed_share_commit {
                 return Err("Share commit verification failed".to_owned());
             }
@@ -161,40 +268,7 @@ pub fn lagrange_interpolate_whole_polynomial(
     assert!(!known_points.is_empty() || !missing_points.is_empty());
 
     let n = known_points.len() + missing_points.len();
-    let factorial: Vec<Fr> = std::iter::once(Fr::one())
-        .chain((1..n).scan(Fr::one(), |state, i| {
-            *state *= Fr::from(i as u64);
-            Some(*state)
-        }))
-        .collect();
-
-    // inv_fact[i] = 1 / factorial[i]
-    let inv_factorial: Vec<Fr> = (0..n)
-        .rev()
-        .scan(
-            factorial[n - 1]
-                .inverse()
-                .expect("This is guaranteed to be non-zero"),
-            |cur_state, i| {
-                let ith_value = *cur_state;
-                *cur_state *= Fr::from(i as u64);
-                Some(ith_value)
-            },
-        )
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .collect();
-
-    let inv: Vec<Fr> = (0..n)
-        .map(|i| {
-            if i == 0 {
-                Fr::zero() //This should never be used
-            } else {
-                inv_factorial[i] * factorial[i - 1]
-            }
-        })
-        .collect();
+    let (factorial, inv_factorial, inv) = precalculated_factorials_and_inverses(n);
 
     // For x, calculates the multiplication of (x - i) for all i in known_points (known_points = 0..n \ missing_points)
     // returns the inverse of the multiplication result, based on the parameter
@@ -252,18 +326,6 @@ mod tests {
     use rand::{SeedableRng, seq::index::sample};
     use rand_chacha::ChaCha20Rng;
     use std::collections::HashSet;
-    #[test]
-    fn test_polynomial_eval() {
-        let polynomial = Polynomial::<Fr>::rand(rand::thread_rng(), 2);
-
-        match polynomial.0.as_slice() {
-            &[a, b, c] => {
-                let x = Fr::rand(&mut rand::thread_rng());
-                assert_eq!(polynomial.eval_at(x), a + b * x + c * x * x);
-            }
-            _ => unreachable!(),
-        }
-    }
 
     #[test]
     fn test_commit_verification() {
@@ -324,7 +386,7 @@ mod tests {
                 .map(|x| x + 1)
                 .collect::<Vec<_>>();
             let polynomial = Polynomial::rand(seed_rng, n_revealed - 1);
-            let points = polynomial.shares(n_total); //points[i].0 = i
+            let points = polynomial.shares(n_total);
 
             let aux_set: HashSet<_> = hidden_points.iter().copied().collect();
             let known_points: Vec<(usize, Fr)> = points
@@ -336,6 +398,23 @@ mod tests {
 
             for (x, y) in hidden_points.into_iter().zip(answer.into_iter()) {
                 assert_eq!(points[x].1, y);
+                assert_eq!(polynomial.eval_at(x), y);
+            }
+        }
+    }
+
+    #[test]
+    fn test_suffix_interpolation() {
+        for (n_revealed, n_hidden) in vec![(5usize, 2usize), (100, 10), (175, 7)] {
+            // Assumes one of the revealed ones is 0, as it will be in application, includes it in the n_revealed ones
+            let n_total = n_revealed + n_hidden;
+            let seed_rng = ChaCha20Rng::seed_from_u64(42);
+            let polynomial = Polynomial::rand(seed_rng, n_revealed - 1);
+            let points = polynomial.shares(n_total);
+            let answer = polynomial.eval_at_suffix_points(n_hidden);
+            for (x, y) in (n_revealed..n_total).into_iter().zip(answer.into_iter()) {
+                assert_eq!(points[x].1, y);
+                assert_eq!(polynomial.eval_at(x), y);
             }
         }
     }

--- a/src/cac/vsss.rs
+++ b/src/cac/vsss.rs
@@ -97,42 +97,104 @@ impl ShareCommits {
     }
 }
 
-// find the missing point by using the Lagrange interpolation, see https://en.wikipedia.org/wiki/Lagrange_polynomial
-// Input is a vec of (index, value), where index is 0-based
-pub fn lagrange_interpolate_at_index(points: &[(usize, Fr)], index: usize) -> Fr {
-    lagrange_interpolate_at_x(points, Fr::from((index + 1) as u64))
-}
+/// Returns the values of the polynomial defined by known_points at missing_points, in the given order
+/// Assumes that points in the two sets are disjoint and their union is set of natural numbers smaller than < n (including 0) for n = len(known_points) + len(missing_points)
+/// Uses the fact that the number of missing points will be small compared to the known ones to evalute polynomials with factorials
+/// so, assuming field inversion and multiplication complexity are I and M, total complexity is O(I + len(missing_points) * n * O)
+pub fn lagrange_interpolate_whole_polynomial(
+    known_points: &[(usize, Fr)],
+    missing_points: &[usize],
+) -> Vec<Fr> {
+    assert!(!known_points.is_empty() || !missing_points.is_empty());
 
-// internal function that allows also queying g(0)
-fn lagrange_interpolate_at_x(points: &[(usize, Fr)], x: Fr) -> Fr {
-    let sc = |val: usize| Fr::from(val as u64);
-    points
-        .iter()
-        .enumerate()
-        .fold(Fr::zero(), |result, (i, (idx, y_i))| {
-            let x_i = sc(*idx + 1); // share 0 corresponds to x=1
-            // Compute L_i(x)
-            let (num, denum) = points.iter().enumerate().filter(|(j, _)| *j != i).fold(
-                (Fr::one(), Fr::one()),
-                |(num, denum), (_, (idx, _))| {
-                    let x_j = sc(*idx + 1); // share 0 corresponds to x=1
+    let n = known_points.len() + missing_points.len();
+    let factorial: Vec<Fr> = std::iter::once(Fr::one())
+        .chain((1..n).scan(Fr::one(), |state, i| {
+            *state *= Fr::from(i as u64);
+            Some(*state)
+        }))
+        .collect();
 
-                    (num * (x - x_j), denum * (x_i - x_j))
-                },
-            );
+    // inv_fact[i] = 1 / factorial[i]
+    let inv_factorial: Vec<Fr> = (0..n)
+        .rev()
+        .scan(
+            factorial[n - 1]
+                .inverse()
+                .expect("This is guaranteed to be non-zero"),
+            |cur_state, i| {
+                let ith_value = *cur_state;
+                *cur_state *= Fr::from(i as u64);
+                Some(ith_value)
+            },
+        )
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
 
-            // calculate li = num / denum = num * denum^{-1}
-            let denum_inv = denum.inverse().expect("x_i - x_j must be nonzero");
-            let li = num * denum_inv;
-
-            result + *y_i * li
+    let inv: Vec<Fr> = (0..n)
+        .map(|i| {
+            if i == 0 {
+                Fr::zero() //This should never be used
+            } else {
+                inv_factorial[i] * factorial[i - 1]
+            }
         })
+        .collect();
+
+    // For x, calculates the multiplication of (x - i) for all i in known_points (known_points = 0..n \ missing_points)
+    // returns the inverse of the multiplication result, based on the parameter
+    let get_coeff = |x: usize, is_inverse: bool| {
+        // corner case checks for 0 and n - 1 are not needed since inv_factorial[0] = factorial[0] = 1
+        let mut result: Fr = if is_inverse {
+            inv_factorial[x] * inv_factorial[n - 1 - x]
+        } else {
+            factorial[x] * factorial[n - 1 - x]
+        };
+        if (n - x).is_multiple_of(2) {
+            result *= -Fr::one();
+        }
+        for i in missing_points {
+            if *i == x {
+                continue;
+            };
+            result *= if is_inverse {
+                Fr::from(x as i64 - *i as i64)
+            } else if *i < x {
+                inv[x - *i]
+            } else {
+                -inv[*i - x]
+            }
+        }
+        result
+    };
+
+    let lagrange_basis_polynomial_coeffs: Vec<(usize, Fr)> = known_points
+        .iter()
+        .map(|(x, y)| (*x, get_coeff(*x, true) * y))
+        .collect();
+
+    missing_points
+        .iter()
+        .map(|x| {
+            let all_differences = get_coeff(*x, false);
+            lagrange_basis_polynomial_coeffs
+                .iter()
+                .fold(Fr::zero(), |result, (i, coeff_i)| {
+                    let ith_diff_inv: Fr = if i < x { inv[x - i] } else { -inv[i - x] };
+                    result + ith_diff_inv * all_differences * *coeff_i
+                })
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    use rand::{SeedableRng, seq::index::sample};
+    use rand_chacha::ChaCha20Rng;
+    use std::collections::HashSet;
     #[test]
     fn test_polynomial_eval() {
         let polynomial = Polynomial::<Fr>::rand(rand::thread_rng(), 2);
@@ -143,33 +205,6 @@ mod tests {
                 assert_eq!(polynomial.eval_at(x), a + b * x + c * x * x);
             }
             _ => unreachable!(),
-        }
-    }
-
-    #[test]
-    fn test_interpolation_from_coefficients() {
-        let polynomial_degree = 3;
-        let polynomial = Polynomial::rand(rand::thread_rng(), polynomial_degree);
-
-        let num_shares = polynomial_degree + 1;
-        let points = polynomial.shares(num_shares);
-
-        let secret = lagrange_interpolate_at_x(&points, Fr::zero());
-
-        assert_eq!(secret, polynomial.0[0]);
-    }
-
-    #[test]
-    fn test_interpolate_missing_shares() {
-        let polynomial_degree = 3;
-        let polynomial = Polynomial::rand(rand::thread_rng(), polynomial_degree);
-        let points = polynomial.shares(6);
-        let selected_points = &points[..polynomial_degree + 1];
-        let missing_points = &points[polynomial_degree + 1..];
-
-        for (i, share) in missing_points.iter() {
-            let reconstructed = lagrange_interpolate_at_index(selected_points, *i);
-            assert_eq!(reconstructed, *share);
         }
     }
 
@@ -186,5 +221,33 @@ mod tests {
 
         let shares = polynomial.shares(num_shares);
         share_commits.verify_shares(&shares).unwrap();
+    }
+
+    #[test]
+    fn test_interpolation() {
+        for (n_revealed, n_hidden) in vec![(5usize, 2usize), (100, 50), (300, 7)] {
+            // Assumes one of the revealed ones is 0, as it will be in application, includes it in the n_revealed ones
+            let n_total = n_revealed + n_hidden;
+            let mut seed_rng = ChaCha20Rng::seed_from_u64(42);
+            let hidden_points = sample(&mut seed_rng, n_total, n_hidden)
+                .into_vec()
+                .into_iter()
+                .map(|x| x + 1)
+                .collect::<Vec<_>>();
+            let polynomial = Polynomial::rand(seed_rng, n_revealed - 1);
+            let points = polynomial.shares(n_total); //points[i].0 = i
+
+            let aux_set: HashSet<_> = hidden_points.iter().copied().collect();
+            let known_points: Vec<(usize, Fr)> = points
+                .clone()
+                .into_iter()
+                .filter(|(x, _)| !aux_set.contains(x))
+                .collect();
+            let answer = lagrange_interpolate_whole_polynomial(&known_points, &hidden_points);
+
+            for (x, y) in hidden_points.into_iter().zip(answer.into_iter()) {
+                assert_eq!(points[x].1, y);
+            }
+        }
     }
 }

--- a/src/cac/vsss.rs
+++ b/src/cac/vsss.rs
@@ -100,7 +100,7 @@ impl ShareCommits {
 /// Returns the values of the polynomial defined by known_points at missing_points, in the given order
 /// Assumes that points in the two sets are disjoint and their union is set of natural numbers smaller than < n (including 0) for n = len(known_points) + len(missing_points)
 /// Uses the fact that the number of missing points will be small compared to the known ones to evalute polynomials with factorials
-/// so, assuming field inversion and multiplication complexity are I and M, total complexity is O(I + len(missing_points) * n * O)
+/// so, assuming field inversion and multiplication complexity are I and M, total complexity is O(I + len(missing_points) * n * M)
 pub fn lagrange_interpolate_whole_polynomial(
     known_points: &[(usize, Fr)],
     missing_points: &[usize],
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_interpolation() {
-        for (n_revealed, n_hidden) in vec![(5usize, 2usize), (100, 50), (300, 7)] {
+        for (n_revealed, n_hidden) in vec![(5usize, 2usize), (100, 10), (175, 7)] {
             // Assumes one of the revealed ones is 0, as it will be in application, includes it in the n_revealed ones
             let n_total = n_revealed + n_hidden;
             let mut seed_rng = ChaCha20Rng::seed_from_u64(42);


### PR DESCRIPTION
Changes the representation and commitment of polynomials to point value form for better scaling, especially for evaluating polynomials with the domain of EC points. Assuming there are `a` revealed points and `b` hidden points, previous algorithm used around `2 * (a + b) * a * log_2(a)` (log from exponentiation) EC additions, this version uses around `a * b * 256` (256 from exponentiation). (Although it doesn't look like it, it might be slower with the current parameters, so further performance testing before merging would be preferable.) (Whole work is on top of #59)