### PR TITLE
refactor(modes): diff sources of rand for `GarbleMode`

### DIFF
--- a/src/cac/adaptor_sigs.rs
+++ b/src/cac/adaptor_sigs.rs
@@ -461,7 +461,7 @@ mod bitvm_tests {
 
         // Test with different order of sigs: should fail
         tx.input[0].witness = [
-            sigs.iter().cloned().collect::<Vec<_>>(), // note: omitted .rev()
+            sigs.to_vec(), // note: omitted .rev()
             vec![script.to_bytes(), control_block.clone()],
         ]
         .concat()

--- a/src/cac/vsss.rs
+++ b/src/cac/vsss.rs
@@ -1,10 +1,12 @@
-use super::utils::neg_pos_sum_of_powers_of_two;
+use std::ops::{Add, Mul};
+
 use ark_ec::{PrimeGroup, scalar_mul::BatchMulPreprocessing};
 use ark_ff::{BigInteger, Field, One, PrimeField, UniformRand, Zero};
 use ark_secp256k1::{Fr, Projective};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::ops::{Add, Mul};
+
+use super::utils::neg_pos_sum_of_powers_of_two;
 
 pub struct Secp256k1 {
     pub generator: BatchMulPreprocessing<Projective>,
@@ -343,14 +345,13 @@ pub fn lagrange_interpolate_whole_polynomial(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
+    use std::{collections::HashSet, time::Instant};
 
     use ark_ec::ScalarMul;
-
-    use super::*;
     use rand::{SeedableRng, seq::index::sample};
     use rand_chacha::ChaCha20Rng;
-    use std::collections::HashSet;
+
+    use super::*;
 
     #[test]
     fn test_commit_verification() {
@@ -401,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_interpolation() {
-        for (n_revealed, n_hidden) in vec![(5usize, 2usize), (100, 10), (175, 7)] {
+        for (n_revealed, n_hidden) in [(5usize, 2usize), (100, 10), (175, 7)] {
             // Assumes one of the revealed ones is 0, as it will be in application, includes it in the n_revealed ones
             let n_total = n_revealed + n_hidden;
             let mut seed_rng = ChaCha20Rng::seed_from_u64(42);
@@ -430,14 +431,14 @@ mod tests {
 
     #[test]
     fn test_suffix_interpolation() {
-        for (n_revealed, n_hidden) in vec![(5usize, 2usize), (100, 10), (175, 7)] {
+        for (n_revealed, n_hidden) in [(5usize, 2usize), (100, 10), (175, 7)] {
             // Assumes one of the revealed ones is 0, as it will be in application, includes it in the n_revealed ones
             let n_total = n_revealed + n_hidden;
             let seed_rng = ChaCha20Rng::seed_from_u64(42);
             let polynomial = Polynomial::rand(seed_rng, n_revealed - 1);
             let points = polynomial.shares(n_total);
             let answer = polynomial.eval_at_suffix_points::<false>(n_hidden);
-            for (x, y) in (n_revealed..n_total).into_iter().zip(answer.into_iter()) {
+            for (x, y) in (n_revealed..n_total).zip(answer.into_iter()) {
                 assert_eq!(points[x].1, y);
                 assert_eq!(polynomial.eval_at(x), y);
             }

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -197,7 +197,7 @@ impl<H: GateHasher, CTH: CiphertextHandler> CircuitBuilder<GarbleMode<H, CTH>> {
     {
         CircuitBuilder::run_streaming(
             inputs,
-            GarbleMode::new(live_wires_capacity, seed, handler),
+            GarbleMode::new_with_seed(live_wires_capacity, seed, handler),
             f,
         )
     }

--- a/src/circuit/modes.rs
+++ b/src/circuit/modes.rs
@@ -10,7 +10,10 @@ pub type Execute = crate::circuit::StreamingMode<ExecuteMode>;
 // Collapse thin wrappers; tests live in mode files.
 
 pub mod garble_mode;
-pub use garble_mode::{GarbleMode, GarbledWire};
+pub use garble_mode::{
+    GarbleMode, GarbledWire, GarbledWireLabelSource, RandomGarbledWireLabelSource,
+    SeededGarbledWireLabelSource, VecGarbledWireLabelSource, VecGarbledWireLabelSourceError,
+};
 
 // Collapse thin wrappers; tests live in mode files.
 


### PR DESCRIPTION
We will now be able to create `GarbleMode` from a pre-defined `label0` vector and this will allow future migrations to VSSS

Part of #66