### PR TITLE
feat: implement vsss

### DIFF
--- a/docs/vsss.md
+++ b/docs/vsss.md
@@ -1,0 +1,92 @@
+# Setup and Evaluation
+
+## Setup
+
+#### Step 1 – Committing
+
+##### Step 1.1 – Wide Label creation
+
+- The garbler generates random polynomials of degree `n - f`. Each polynomial will represent one wide label value. Since we assume wide labels to represent 8 bits, and we have 256 wide label value per byte, for `x` input wires we have roughly `32x` polynomials.
+
+##### Step 1.2 – Circuit Generation
+
+- Garbler generates `n` garbled circuits: for each `i ∈ [n]`, create garbled circuit `GC_i` from a random seed.
+
+##### Step 1.3 – Wide Label Lookup Table Creation
+
+- The garbler computes the wide labels from the previously generated polynomials, and uses them to generate wide label lookup tables.
+
+##### Step 1.3 – Label and table commits
+
+- For every instance `i`, the garbler sends:
+
+```
+Commit(i) = {
+    ciphertext_hash: H_ciphertext(all_ciphertexts_i),
+    input_commits: [(H_label(wire_j_label0), H_label(wire_j_label1))]_j,
+    output_commit: (H_label(L_valid), H_label(L_invalid)),
+    constants: (true_wire_value, false_wire_value)
+    wide_label_lookup_table_commit: H_wide_label_ciphertexts(all_wide_label_lookup_tables_i),
+    share_commits: for each polynomial j, share_commit(i, j),
+}
+```
+
+Additionally, the garbler sends a global commit - for each polynomial, the garbler sends commits to the coefficients to the evaluator.
+
+```
+
+#### Step 2 – Checking commits (part 1)
+
+- Evaluator checks that the share commits are consistent with the polynomial commits.
+
+
+#### Step 3 – Selecting
+
+- Evaluator randomly partitions `[n]` into a check set `C` (size `n-f`) and an evaluation set `E` (size `f`).
+- Evaluator sends the indices in `E` together with ciphertext handlers to receive ciphertext streams for finalized instances.
+
+
+#### Step 4 – Opening
+
+- Garbler reveals seeds for every instance in `C`:
+  ```
+  OpenSeeds = {(index_i, seed_i) : i ∈ C}
+  ```
+- Garbler reveals al wide label values (= shares) for every instance in `C`.
+- Evaluator checks that the wide label values are consistent with the share commits.
+- Evaluator regenerates the wide label lookup tables and checks that they are consistent with corresponding `wide_label_lookup_table_commit`.
+- For each closed instance `i ∈ E`, the Garbler re‑garbles `GC_i` deterministically from its private seed and streams the resulting ciphertext blocks to Evaluator‑supplied handlers; the Evaluator recomputes the AES accumulating hash and verifies it matches `Commit_1(i).ciphertext_hash`. The ciphertext stream is transient and does not need to be persisted.
+- Any mismatch (open or closed) aborts the protocol.
+
+#### Step 5 – Setting up adaptor signatures
+
+Note: the current demo does not use adaptor signatures yet.
+
+- Evaluator chooses an index `q` from one of the remaining `f` indices to be used in asserts.
+- Evaluator sets up adaptor signatures for the instance `q`, assuming a previously agreed-upon bitcoin transaction. It sends the adaptor signatures to the garbler.
+
+
+### Phase II: Evaluation
+
+#### Step 1 – Publishing
+
+- The garbler reveals wide labels for the instance `q` by submitting the transaction including the adaptor signatures on bitcoin
+
+#### Step 2 – Extraction and polynomial reconstruction
+
+- Evaluator extracts the wide labels for the instance `q` from the adaptor signatures.
+- Evaluator uses the labels from the `C` instances together with the newly revealed labels to interpolate the labels for all instances in `E`.
+
+#### Step 3 – Evaluating
+
+- For each `i ∈ E`:
+  - Evaluate `GC_i` from saved ciphertexts to obtain `L_valid` or `L_invalid` for each.
+- If any `L_invalid` is obtained, the evaluator can post the disprove transaction by supplying the `L_invalid`.
+
+## Message Summary
+
+- (Garbler → Evaluator) Vssscommits: {Commit_1(i)}_{i∈[n]} + Polynomial commits
+- (Evaluator → Garbler) FinalizeChallenge: indices to finalize
+- (Garbler → Evaluator) OpenInstances: seeds and wide labels of all items in `C`, and garbled wide label lookup table for all items in `E`
+- (Evaluator → Garbler) Adaptor signatures and index of 1 of the instances in `E`
+- (Garbler → Bitcoin) Assert: Selected widelabels for given 1 instance.

--- a/examples/groth16_cut_and_choose_vsss.rs
+++ b/examples/groth16_cut_and_choose_vsss.rs
@@ -1,0 +1,458 @@
+//! High-level driver showcasing the cut-and-choose Setup/Evaluate flow from
+//! `docs/gsv_spec.md` using the Groth16 verifier gadget.
+use std::{path::PathBuf, thread};
+
+use ark_ff::AdditiveGroup;
+use crossbeam::channel::{self};
+use garbled_snark_verifier::{
+    EvaluatedWire,
+    ark::{
+        self, Bn254, CircuitSpecificSetupSNARK, Groth16 as ArkGroth16, ProvingKey as ArkProvingKey,
+        SNARK, UniformRand,
+    },
+    cac::vsss::lagrange_interpolate_whole_polynomial,
+    circuit::CiphertextSender,
+    cut_and_choose::{
+        Evaluator, EvaluatorCaseInput, FileCiphertextHandlerProvider, VsssGarbler,
+        vsss::{
+            Canonical, FinalizeChallenge, SetupBroadcast, SetupResponse, VsssStreamReceivers,
+            encode_input, transpose,
+        },
+    },
+    garbled_groth16::{self, EvaluatorCompressedInput},
+    groth16_cut_and_choose::{self as ccn, DEFAULT_CAPACITY},
+    hashers::DefaultLabelCommitHasher,
+};
+use itertools::Itertools;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use tracing::info;
+
+// Configuration constants - modify these as needed
+const TOTAL_INSTANCES: usize = 4;
+const FINALIZE_INSTANCES: usize = 2;
+const OUT_DIR: &str = "target/cut_and_choose";
+const K_CONSTRAINTS: u32 = 5; // 2^k constraints
+const IS_PROOF_CORRECT: bool = true;
+
+// Calculate and display total gates to process
+const GATES_PER_INSTANCE: u64 = 11_174_708_821;
+
+use dummy_circuit::verify_compressed as circuit_verify;
+// use garbled_groth16::verify_compressed as circuit_verify;
+
+mod dummy_circuit {
+    use garbled_snark_verifier::{
+        CircuitContext, Gate, WireId,
+        circuit::{TRUE_WIRE, WiresObject},
+        gadgets::groth16::Groth16VerifyCompressedInputWires,
+    };
+
+    pub fn verify_compressed<C: CircuitContext>(
+        circuit: &mut C,
+        input: &Groth16VerifyCompressedInputWires,
+    ) -> WireId {
+        let input_wires = input.to_wires_vec();
+        let output_wire = circuit.issue_wire();
+
+        let mut it = input_wires.iter();
+        let mut one_bits: Vec<WireId> = Vec::new();
+        let mut zero_bits: Vec<WireId> = Vec::new();
+        for i in 0.. {
+            zero_bits.extend(it.by_ref().take(i));
+            match it.next() {
+                Some(wire) => {
+                    one_bits.push(wire.clone());
+                }
+                None => {
+                    break;
+                }
+            }
+        }
+
+        let ones_ok = one_bits
+            .into_iter()
+            .reduce(|a, b| {
+                let c = circuit.issue_wire();
+                circuit.add_gate(Gate::and(a, b, c));
+                c
+            })
+            .unwrap();
+
+        let zeroes_not_ok = zero_bits
+            .into_iter()
+            .reduce(|a, b| {
+                let c = circuit.issue_wire();
+                circuit.add_gate(Gate::or(a, b, c));
+                c
+            })
+            .unwrap();
+
+        let zeroes_ok = circuit.issue_wire();
+        circuit.add_gate(Gate::xor(zeroes_not_ok, TRUE_WIRE, zeroes_ok));
+
+        circuit.add_gate(Gate::and(ones_ok, zeroes_ok, output_wire));
+
+        output_wire
+    }
+}
+
+// Simple multiplicative circuit used to produce a valid Groth16 proof.
+#[derive(Copy, Clone)]
+#[allow(unused)]
+struct DummyCircuit<F: ark::PrimeField> {
+    pub a: Option<F>,
+    pub b: Option<F>,
+    pub num_variables: usize,
+    pub num_constraints: usize,
+}
+
+impl<F: ark::PrimeField> ark::ConstraintSynthesizer<F> for DummyCircuit<F> {
+    fn generate_constraints(
+        self,
+        cs: ark::ConstraintSystemRef<F>,
+    ) -> Result<(), ark::SynthesisError> {
+        let a = cs.new_witness_variable(|| self.a.ok_or(ark::SynthesisError::AssignmentMissing))?;
+        let b = cs.new_witness_variable(|| self.b.ok_or(ark::SynthesisError::AssignmentMissing))?;
+        let c = cs.new_input_variable(|| {
+            let a = self.a.ok_or(ark::SynthesisError::AssignmentMissing)?;
+            let b = self.b.ok_or(ark::SynthesisError::AssignmentMissing)?;
+            Ok(a * b)
+        })?;
+
+        // pad witnesses
+        for _ in 0..(self.num_variables - 3) {
+            let _ =
+                cs.new_witness_variable(|| self.a.ok_or(ark::SynthesisError::AssignmentMissing))?;
+        }
+
+        // repeat the same multiplicative constraint
+        for _ in 0..self.num_constraints - 1 {
+            cs.enforce_constraint(ark::lc!() + a, ark::lc!() + b, ark::lc!() + c)?;
+        }
+
+        // final no-op constraint keeps ark-relations happy
+        cs.enforce_constraint(ark::lc!(), ark::lc!(), ark::lc!())?;
+        Ok(())
+    }
+}
+
+fn main() {
+    if !garbled_snark_verifier::hardware_aes_available() {
+        eprintln!(
+            "Warning: AES hardware acceleration not detected; using software AES (not constant-time)."
+        );
+    }
+
+    garbled_snark_verifier::init_tracing();
+
+    // Configuration
+    let total = TOTAL_INSTANCES;
+    let finalize = FINALIZE_INSTANCES;
+    let out_dir: PathBuf = OUT_DIR.into();
+    let k = K_CONSTRAINTS; // 2^k constraints
+
+    // 1) Build and prove a tiny multiplicative circuit
+    let mut rng = ChaCha20Rng::seed_from_u64(12345);
+    let circuit = DummyCircuit::<ark::Fr> {
+        a: Some(ark::Fr::rand(&mut rng)),
+        b: Some(ark::Fr::rand(&mut rng)),
+        num_variables: 10,
+        num_constraints: 1 << k,
+    };
+    let (pk, vk) = ark::Groth16::<ark::Bn254>::setup(circuit, &mut rng).expect("setup");
+    let public_input = if IS_PROOF_CORRECT {
+        circuit.a.unwrap() * circuit.b.unwrap()
+    } else {
+        ark::Fr::ZERO
+    };
+
+    // Package inputs for garbling/evaluation gadgets
+    let g_input = garbled_groth16::GarblerInput {
+        public_params_len: 1,
+        vk: vk.clone(),
+    }
+    .compress();
+
+    let total_gates = GATES_PER_INSTANCE * total as u64;
+    info!("Starting cut-and-choose with {} instances", total);
+
+    info!(
+        "Total gates to process in first stage: {:.2}B",
+        total_gates as f64 / 1_000_000_000.0
+    );
+
+    info!(
+        "Gates per instance: {:.2}B",
+        GATES_PER_INSTANCE as f64 / 1_000_000_000.0
+    );
+
+    let (g2e_tx, g2e_rx) = channel::unbounded::<SetupBroadcast<DefaultLabelCommitHasher>>();
+    let (e2g_tx, e2g_rx) = channel::unbounded::<SetupResponse<CiphertextSender>>();
+
+    let garbler_cfg = ccn::Config::new(total, finalize, g_input.clone());
+    let evaluator_cfg = garbler_cfg.clone();
+
+    let garbler = thread::spawn(move || {
+        run_garbler(
+            garbler_cfg,
+            pk.clone(),
+            circuit,
+            public_input,
+            g2e_tx,
+            e2g_rx,
+        );
+    });
+
+    let evaluator = thread::spawn(move || run_evaluator(evaluator_cfg, out_dir, g2e_rx, e2g_tx));
+
+    garbler.join().unwrap();
+    let evaluator = evaluator.join().unwrap();
+
+    let errors = evaluator
+        .iter()
+        .filter_map(|(i, ew)| (ew.value != IS_PROOF_CORRECT).then_some(i))
+        .collect::<Vec<_>>();
+
+    assert!(errors.is_empty(), "errors: {errors:?}")
+}
+
+#[allow(unused)]
+fn run_garbler(
+    cfg: ccn::Config,
+    pk: ArkProvingKey<Bn254>,
+    circuit: DummyCircuit<ark::Fr>,
+    public_input: ark::Fr,
+    g2e_tx: channel::Sender<SetupBroadcast<DefaultLabelCommitHasher>>,
+    e2g_rx: channel::Receiver<SetupResponse<CiphertextSender>>,
+) {
+    let mut seed_rng = ChaCha20Rng::seed_from_u64(rand::thread_rng().r#gen());
+
+    info!(
+        "Garbler: {total}/{to_finalize}",
+        total = cfg.total(),
+        to_finalize = cfg.to_finalize(),
+    );
+
+    let mut g = ccn::VsssGarbler::from_inner(VsssGarbler::create(
+        &mut seed_rng,
+        cfg.clone(),
+        DEFAULT_CAPACITY,
+        circuit_verify,
+    ));
+
+    g2e_tx
+        .send(SetupBroadcast::Commit(
+            g.commit::<DefaultLabelCommitHasher>(),
+        ))
+        .expect("send commits");
+
+    // Step 2 — Evaluator challenges the Garbler with the finalize set.
+    let SetupResponse::FinalizeChallenge(finalize_senders) =
+        e2g_rx.recv().expect("recv finalize senders");
+
+    let finalize_indices = finalize_senders.iter().map(|x| x.index).collect_vec();
+
+    let (opened_instance_data, finalized_instance_data) =
+        g.inner().open_commit(finalize_senders, circuit_verify);
+
+    let finalized_instance_data_indices = finalized_instance_data
+        .iter()
+        .map(|x| x.index)
+        .collect_vec();
+
+    let opened_instance_data_indices = opened_instance_data.iter().map(|x| x.index).collect_vec();
+    let idx_to_reveal = finalized_instance_data[0].index;
+
+    let (garbling_threads, wide_label_looksup): (Vec<_>, Vec<_>) = finalized_instance_data
+        .into_iter()
+        .map(|x| (x.garbling_thread, (x.index, x.wide_label_lookup)))
+        .unzip();
+
+    g2e_tx
+        .send(SetupBroadcast::OpenInstances(
+            opened_instance_data,
+            wide_label_looksup,
+        ))
+        .expect("send open instances");
+
+    garbling_threads.into_iter().for_each(|thread| {
+        thread.join().unwrap();
+    });
+
+    let challenge_proof =
+        ArkGroth16::<Bn254>::prove(&pk, circuit, &mut ChaCha20Rng::seed_from_u64(42))
+            .expect("prove");
+
+    // Verify the proof is valid before garbling
+    let is_valid = ArkGroth16::<Bn254>::verify(&cfg.input().vk, &[public_input], &challenge_proof)
+        .expect("verify");
+
+    assert_eq!(
+        is_valid, IS_PROOF_CORRECT,
+        "Proof must be valid before garbling!"
+    );
+
+    let inputs = g
+        .prepare_input_labels(vec![public_input], challenge_proof, idx_to_reveal)
+        .input;
+
+    let encoded = encode_input(&inputs);
+
+    // Step 4: translate input labels to wide labels
+    let wide_labels = g
+        .wide_labels_for(idx_to_reveal)
+        .chunks(256)
+        .into_iter()
+        .zip(encoded.chunks(8))
+        .map(|(wide_labels, bit_vals)| {
+            let wide_label_idx = bit_vals.iter().fold(0, |acc, &val| acc * 2 + val as u8);
+            Canonical(wide_labels[wide_label_idx as usize])
+        })
+        .collect_vec();
+
+    g2e_tx
+        .send(SetupBroadcast::Assert(idx_to_reveal, wide_labels))
+        .expect("send open instances");
+}
+
+#[allow(unused)]
+fn run_evaluator(
+    cfg: ccn::Config,
+    out_dir: PathBuf,
+    g2e_rx: channel::Receiver<SetupBroadcast<DefaultLabelCommitHasher>>,
+    e2g_tx: channel::Sender<SetupResponse<CiphertextSender>>,
+) -> Vec<(usize, EvaluatedWire)> {
+    let mut rng = ChaCha20Rng::seed_from_u64(rand::thread_rng().r#gen());
+
+    let finalize = cfg.to_finalize();
+
+    // Step 1 — receive Commits.
+    let SetupBroadcast::Commit(commits) = g2e_rx.recv().expect("recv commits") else {
+        panic!("unexpected message; expected commits")
+    };
+
+    // Evaluator chooses which instances to finalize with first commits
+    let mut eval: Evaluator<garbled_groth16::GarblerCompressedInput, DefaultLabelCommitHasher> =
+        Evaluator::create_vsss(&mut rng, cfg.clone(), commits);
+    let finalize_indices: Vec<usize> = eval.finalized_indexes().to_vec();
+
+    let (tx_data, receivers): (Vec<_>, Vec<_>) = finalize_indices
+        .iter()
+        .map(|&index| {
+            let (label_tx, label_rx) = channel::bounded(1024);
+            let tx = FinalizeChallenge {
+                index,
+                ciphertext_handler: label_tx,
+            };
+            let rx = VsssStreamReceivers {
+                index,
+                ciphertext_receiver: label_rx,
+            };
+            (tx, rx)
+        })
+        .unzip();
+
+    e2g_tx
+        .send(SetupResponse::FinalizeChallenge(tx_data))
+        .expect("send finalize challenge");
+
+    let SetupBroadcast::OpenInstances(open_instance_data, wide_label_lookups) =
+        g2e_rx.recv().expect("recv commits")
+    else {
+        panic!("unexpected message; expected commits")
+    };
+
+    let out_dir = PathBuf::from("target/cut_and_choose_test_simple");
+    let handler_provider =
+        FileCiphertextHandlerProvider::new(out_dir.clone(), None).expect("create sink provider");
+
+    eval.run_regarbling_vsss(
+        &open_instance_data,
+        &receivers,
+        &handler_provider,
+        DEFAULT_CAPACITY,
+        circuit_verify,
+        &wide_label_lookups,
+    )
+    .expect("regarbling ok");
+
+    let SetupBroadcast::Assert(index, wide_labels) = g2e_rx.recv().expect("recv asserts") else {
+        panic!("unexpected message; expected asserts")
+    };
+
+    let value_indices = {
+        let wide_label_lookup = &wide_label_lookups.iter().find(|x| x.0 == index).unwrap().1;
+        wide_labels
+            .iter()
+            .zip(wide_label_lookup.iter())
+            .map(|(wide_label, wide_label_lookup)| wide_label_lookup.lookup_index(&wide_label.0))
+            .collect_vec()
+    };
+
+    let known_labels = open_instance_data
+        .into_iter()
+        .map(|x| {
+            (
+                x.index, // instance index
+                x.shares
+                    .chunks(256)
+                    .zip(value_indices.iter())
+                    .map(|(share, index)| share[*index]) // out of the 256 possible values, use the selected one
+                    .collect_vec(),
+            )
+        })
+        .chain(std::iter::once((index, wide_labels.clone())))
+        .collect_vec();
+
+    let missing_indices = (0..cfg.total())
+        .filter(|&i| !known_labels.iter().any(|(j, _)| j == &i))
+        .collect_vec();
+
+    let num_labels = known_labels[0].1.len();
+    let mut interpolated_labels = vec![];
+
+    for i in 0..num_labels {
+        let known = known_labels
+            .iter()
+            .map(|(j, shares)| (*j, shares[i].0))
+            .collect_vec();
+        let missing = lagrange_interpolate_whole_polynomial(&known, &missing_indices);
+        let canonical = missing.into_iter().map(|x| Canonical(x)).collect_vec();
+        interpolated_labels.push(canonical);
+    }
+
+    let interpolated_labels = transpose(&interpolated_labels);
+
+    let all_finalized_labels = missing_indices
+        .into_iter()
+        .zip(interpolated_labels.into_iter())
+        .chain(std::iter::once((index, wide_labels.clone())));
+
+    let inputs = all_finalized_labels
+        .map(|(index, labels)| {
+            let wide_label_lookup = &wide_label_lookups.iter().find(|x| x.0 == index).unwrap().1;
+
+            let evaluated_wires = labels
+                .iter()
+                .zip(wide_label_lookup.iter())
+                .flat_map(|(wide_label, wide_label_lookup)| {
+                    wide_label_lookup.lookup_evaluated_wires(&wide_label.0)
+                })
+                .collect_vec();
+
+            let input = EvaluatorCompressedInput::from_evaluated_inputs(
+                1,
+                evaluated_wires,
+                cfg.input().vk.clone(),
+            );
+            EvaluatorCaseInput { index, input }
+        })
+        .collect_vec();
+
+    let results = eval
+        .evaluate_from(&out_dir, inputs, DEFAULT_CAPACITY, circuit_verify)
+        .expect("consistency checks should pass for true inputs");
+
+    results
+}

--- a/src/cac/vsss.rs
+++ b/src/cac/vsss.rs
@@ -3,8 +3,11 @@ use std::ops::{Add, Mul};
 use ark_ec::{PrimeGroup, scalar_mul::BatchMulPreprocessing};
 use ark_ff::{BigInteger, Field, One, PrimeField, UniformRand, Zero};
 use ark_secp256k1::{Fr, Projective};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+
+use crate::cut_and_choose::vsss::Canonical;
 
 use super::utils::neg_pos_sum_of_powers_of_two;
 
@@ -28,7 +31,7 @@ impl Secp256k1 {
 
     // Replacement of BatchMulPreprocessing::batch_mul, which (1) uses rayon parallelization
     // and (2) converts the result to an affine point instead of a projective point.
-    fn generator_batch_mul(&self, scalars: &[Fr]) -> Vec<Projective> {
+    pub fn generator_batch_mul(&self, scalars: &[Fr]) -> Vec<Projective> {
         scalars.iter().map(|e| self.windowed_mul(e)).collect()
     }
 
@@ -96,10 +99,19 @@ fn precalculated_factorials_and_inverses(n: usize) -> (Vec<Fr>, Vec<Fr>, Vec<Fr>
     (factorial, inv_factorial, inv)
 }
 
-// This polynomial is in the (point, value) form instead of coefficient form (points are integers in range [0, degree] converted to Fr's)
-// It's used both for polynomials with scalar and projective point domains
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Polynomial<T>(Vec<T>);
+
+impl<T: CanonicalSerialize + CanonicalDeserialize> Polynomial<T> {
+    pub fn to_canonical(self) -> Polynomial<Canonical<T>> {
+        Polynomial(self.0.into_iter().map(Canonical).collect())
+    }
+}
+impl<T: CanonicalSerialize + CanonicalDeserialize + Clone> Polynomial<Canonical<T>> {
+    pub fn from_canonical(&self) -> Polynomial<T> {
+        Polynomial(self.0.iter().map(|x| x.0.clone()).collect())
+    }
+}
 
 impl<T> Polynomial<T>
 where
@@ -205,7 +217,7 @@ impl Polynomial<Fr> {
         Self((0..degree + 1).map(|_| Fr::rand(&mut rand)).collect())
     }
 
-    pub fn coefficient_commits(&self, secp: &Secp256k1) -> PolynomialCommits {
+    pub fn coefficient_commits(&self, secp: &Secp256k1) -> PolynomialCommits<Projective> {
         PolynomialCommits(Polynomial(secp.generator_batch_mul(&self.0)))
     }
 
@@ -223,7 +235,7 @@ impl Polynomial<Fr> {
             .collect()
     }
 
-    pub fn share_commits(&self, secp: &Secp256k1, num_shares: usize) -> ShareCommits {
+    pub fn share_commits(&self, secp: &Secp256k1, num_shares: usize) -> ShareCommits<Projective> {
         let shares = self
             .shares(num_shares)
             .into_iter()
@@ -234,14 +246,35 @@ impl Polynomial<Fr> {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct PolynomialCommits(Polynomial<Projective>);
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PolynomialCommits<T>(Polynomial<T>);
 
-#[derive(Clone, Debug)]
-pub struct ShareCommits(pub Vec<Projective>);
+impl<T: CanonicalSerialize + CanonicalDeserialize> PolynomialCommits<T> {
+    pub fn to_canonical(self) -> PolynomialCommits<Canonical<T>> {
+        PolynomialCommits(self.0.to_canonical())
+    }
+}
 
-impl ShareCommits {
-    pub fn verify(&self, polynomial_commits: &PolynomialCommits) -> Result<(), String> {
+impl<T: CanonicalSerialize + CanonicalDeserialize + Clone> PolynomialCommits<Canonical<T>> {
+    pub fn from_canonical(&self) -> PolynomialCommits<T> {
+        PolynomialCommits(self.0.from_canonical())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShareCommits<T>(pub Vec<T>);
+impl<T: CanonicalSerialize + CanonicalDeserialize> ShareCommits<T> {
+    pub fn to_canonical(self) -> ShareCommits<Canonical<T>> {
+        ShareCommits(self.0.into_iter().map(Canonical).collect())
+    }
+}
+impl<T: CanonicalSerialize + CanonicalDeserialize + Clone> ShareCommits<Canonical<T>> {
+    pub fn from_canonical(&self) -> ShareCommits<T> {
+        ShareCommits(self.0.iter().map(|x| x.0.clone()).collect())
+    }
+}
+impl ShareCommits<Projective> {
+    pub fn verify(&self, polynomial_commits: &PolynomialCommits<Projective>) -> Result<(), String> {
         let n_known = polynomial_commits.0.0.len();
         let n_unknown = self.0.len() - n_known;
         let unknown_points = polynomial_commits

--- a/src/circuit/ciphertext_source.rs
+++ b/src/circuit/ciphertext_source.rs
@@ -105,3 +105,13 @@ impl CiphertextSource for FileSource {
         AESAccumulatingHash::finalize(&self.hasher)
     }
 }
+pub struct DummySource;
+
+impl CiphertextSource for DummySource {
+    type Result = ();
+
+    fn recv(&mut self) -> Option<S> {
+        None
+    }
+    fn finalize(&self) -> Self::Result {}
+}

--- a/src/cut_and_choose/ciphertext_repository.rs
+++ b/src/cut_and_choose/ciphertext_repository.rs
@@ -13,7 +13,7 @@ use tracing::error;
 use crate::{
     AESAccumulatingHash, S,
     circuit::{CiphertextHandler, MultiCiphertextHandler, ciphertext_source},
-    cut_and_choose::CiphertextCommit,
+    cut_and_choose::{CiphertextCommit, vsss::VsssStreamReceivers},
 };
 
 pub trait CiphertextSourceProvider {
@@ -47,6 +47,17 @@ impl CiphertextSourceProvider for Vec<(usize, channel::Receiver<S>)> {
     fn source_for(&self, index: usize) -> Result<Self::Source, Self::Error> {
         self.iter()
             .find_map(|(i, rx)| i.eq(&index).then_some(rx).cloned())
+            .ok_or(())
+    }
+}
+
+impl CiphertextSourceProvider for Vec<VsssStreamReceivers> {
+    type Source = channel::Receiver<S>;
+    type Error = ();
+
+    fn source_for(&self, index: usize) -> Result<Self::Source, Self::Error> {
+        self.iter()
+            .find_map(|x| x.index.eq(&index).then_some(x.ciphertext_receiver.clone()))
             .ok_or(())
     }
 }

--- a/src/cut_and_choose/evaluator.rs
+++ b/src/cut_and_choose/evaluator.rs
@@ -16,13 +16,16 @@ use super::{
 };
 use crate::{
     AESAccumulatingHash, AesNiHasher, EvaluatedWire, GarbleMode, GarbledWire, S, WireId,
+    cac::vsss::{self, PolynomialCommits, ShareCommits},
     circuit::{
         CiphertextHandler, CiphertextSource, CircuitBuilder, CircuitInput, EncodeInput,
         StreamingMode, StreamingResult, modes::EvaluateMode,
     },
     cut_and_choose::{
         CiphertextCommit, CiphertextHandlerProvider, CiphertextSourceProvider,
-        DefaultLabelCommitHasher, LabelCommit, LabelCommitHasher, Seed, commit_label_with,
+        DefaultLabelCommitHasher, GarbledInstance, GarbledWideLabelTable, InstanceWideLabelLookup,
+        LabelCommit, LabelCommitHasher, Seed, commit_label_with,
+        vsss::{OpenVsssInstance, VsssCommit},
         write_commit_hex,
     },
 };
@@ -42,6 +45,9 @@ pub enum Stage<H: LabelCommitHasher> {
         first: Vec<CommitPhaseOne<H>>,
         second: Vec<CommitPhaseTwo<H>>,
     },
+    Vsss {
+        commits: VsssCommit<H>,
+    },
     #[cfg(feature = "sp1-soldering")]
     Soldered {
         first: Vec<CommitPhaseOne<H>>,
@@ -59,6 +65,11 @@ impl<H: LabelCommitHasher> Stage<H> {
             Stage::Empty => None,
             Stage::Created(_) => None,
             Stage::Filled { first, .. } => Some(first),
+            Stage::Vsss {
+                commits: VsssCommit {
+                    circuit_commits, ..
+                },
+            } => Some(circuit_commits),
             #[cfg(feature = "sp1-soldering")]
             Stage::Soldered { first, .. } => Some(first),
         }
@@ -93,6 +104,71 @@ where
     I: Serialize + DeserializeOwned,
     H: LabelCommitHasher,
 {
+    pub fn create_vsss(mut rng: impl Rng, config: Config<I>, commits: VsssCommit<H>) -> Self {
+        let polynomial_commits = commits
+            .polynomial_commits
+            .iter()
+            .map(PolynomialCommits::from_canonical)
+            .collect_vec();
+        let share_commits = commits
+            .share_commits
+            .iter()
+            .map(ShareCommits::from_canonical)
+            .collect_vec();
+
+        let mut x = 0;
+        let allocated = config.input().allocate(|| {
+            x += 1;
+            WireId(x)
+        });
+        let num_inputs = <I as CircuitInput>::collect_wire_ids(&allocated).len();
+
+        let expected_len = (0..num_inputs)
+            .chunks(8)
+            .into_iter()
+            .map(|chunk| {
+                let num_bits = chunk.count();
+                2u32.pow(num_bits as u32) as usize
+            })
+            .sum::<usize>();
+
+        assert_eq!(polynomial_commits.len(), expected_len);
+        assert_eq!(share_commits.len(), expected_len);
+
+        for (polynomial_commits, share_commits) in
+            polynomial_commits.iter().zip(share_commits.iter())
+        {
+            share_commits
+                .verify(polynomial_commits)
+                .expect("Share commit verification failed");
+        }
+
+        assert!(
+            config.to_finalize <= config.total,
+            "to_finalize must be <= total"
+        );
+
+        assert_eq!(commits.circuit_commits.len(), config.total);
+
+        // Sample without replacement: shuffle 0..total and take first `to_finalize`
+        let mut idxs: Vec<usize> = (0..config.total).collect();
+        // Fisher-Yates with unbiased rng
+        for i in (1..idxs.len()).rev() {
+            let j = rng.gen_range(0..=i);
+            idxs.swap(i, j);
+        }
+        idxs.truncate(config.to_finalize);
+        idxs.sort_unstable();
+
+        Self {
+            stage: Stage::Vsss { commits },
+            to_finalize: idxs.into_boxed_slice(),
+            config,
+            nonce: S::from_u128(rng.r#gen()),
+            regarbled: false,
+        }
+    }
+
     // Generate `to_finalize` with `rng` based on data on `Config`
     pub fn create(mut rng: impl Rng, config: Config<I>, commits: Vec<CommitPhaseOne<H>>) -> Self {
         assert!(
@@ -184,6 +260,11 @@ where
             Stage::Empty => None,
             Stage::Created(first) => first.get(index),
             Stage::Filled { first, .. } => first.get(index),
+            Stage::Vsss {
+                commits: VsssCommit {
+                    circuit_commits, ..
+                },
+            } => circuit_commits.get(index),
             #[cfg(feature = "sp1-soldering")]
             Stage::Soldered { first, .. } => first.get(index),
         }
@@ -414,6 +495,157 @@ where
                     }
 
                     Ok(())
+                })
+                .collect::<Result<Vec<()>, ()>>()
+        })?;
+
+        self.regarbled = true;
+
+        Ok(())
+    }
+
+    // 1. Check that `OpenForInstance` matches the ones stored in `self.to_finalize`.
+    // 2. For `Open` run `streaming_garbling` via rayon, where at the end it checks for a match with saved commits
+    #[allow(clippy::result_unit_err)]
+    pub fn run_regarbling_vsss<CSourceProvider, CHandlerProvider, F>(
+        &mut self,
+        open_instance_data: &[OpenVsssInstance],
+        ciphertext_sources_provider: &CSourceProvider,
+        ciphertext_handler_provider: &CHandlerProvider,
+        live_capacity: usize,
+        builder: F,
+        wide_label_lookups: &[(usize, InstanceWideLabelLookup)],
+    ) -> Result<(), ()>
+    where
+        CSourceProvider: CiphertextSourceProvider + Send + Sync,
+        CHandlerProvider: CiphertextHandlerProvider + Send + Sync,
+        CHandlerProvider::Handler: 'static,
+        <CHandlerProvider::Handler as CiphertextHandler>::Result: 'static + Into<CiphertextCommit>,
+        F: Fn(
+                &mut StreamingMode<GarbleMode<AesNiHasher, AESAccumulatingHash>>,
+                &I::WireRepr,
+            ) -> WireId
+            + Send
+            + Sync
+            + Copy,
+    {
+        let Stage::Vsss { commits } = &mut self.stage else {
+            panic!(
+                "Can't run regarbling for not filled Evaluator, got stage: {:#?}",
+                self.stage
+            );
+        };
+
+        let iter = commits.circuit_commits.iter().enumerate();
+
+        let inputs = self.config.input.clone();
+        let to_finalize = &self.to_finalize;
+
+        let secp = vsss::Secp256k1::new();
+        for (i, share_commits) in commits.share_commits.iter().enumerate() {
+            let shares = open_instance_data
+                .iter()
+                .map(|x| (x.index, x.shares[i].0))
+                .collect_vec();
+
+            share_commits
+                .from_canonical()
+                .verify_shares(&secp, &shares)
+                .expect("Received shares inconsistent with commits");
+        }
+
+        super::get_optimized_pool().install(|| {
+            iter.par_bridge()
+                .map(|(index, first_commit)| {
+                    if to_finalize.contains(&index) {
+                        let mut source = match ciphertext_sources_provider.source_for(index) {
+                            Ok(source) => source,
+                            Err(err) => {
+                                error!(index, ?err, "failed to get ciphertext source");
+                                return Err(());
+                            }
+                        };
+
+                        let mut handler = match ciphertext_handler_provider.handler_for(index) {
+                            Ok(sink) => sink,
+                            Err(err) => {
+                                error!(index, ?err, "failed to create ciphertext sink");
+                                return Err(());
+                            }
+                        };
+
+                        while let Some(s) = source.recv() {
+                            handler.handle(s);
+                        }
+
+                        let computed_commit: CiphertextCommit = handler.finalize().into();
+
+                        if computed_commit != first_commit.ciphertext_hash() {
+                            error!("ciphertext corrupted");
+                            return Err(());
+                        }
+
+                        let wide_label_lookup = wide_label_lookups
+                            .iter()
+                            .find(|x| x.0 == index)
+                            .unwrap()
+                            .1
+                            .clone();
+                        let tables_hash = GarbledWideLabelTable::aggregate_hash(&wide_label_lookup);
+                        if tables_hash != commits.garbling_table_commits[index] {
+                            error!("wide label table corrupted");
+                            return Err(());
+                        }
+
+                        Ok(())
+                    } else {
+                        let Some(info) = open_instance_data.iter().find(|x| x.index == index)
+                        else {
+                            error!("failed to find seed");
+                            return Err(());
+                        };
+                        let garbling_seed = info.seed;
+
+                        let inputs = inputs.clone();
+                        let hasher = AESAccumulatingHash::default();
+
+                        let span = tracing::info_span!("regarble", instance = index);
+                        let _enter = span.enter();
+
+                        info!("Starting regarbling of circuit (cut-and-choose)");
+
+                        let res: StreamingResult<
+                            GarbleMode<AesNiHasher, AESAccumulatingHash>,
+                            I,
+                            GarbledWire,
+                        > = CircuitBuilder::streaming_garbling(
+                            inputs.clone(),
+                            live_capacity,
+                            garbling_seed,
+                            hasher,
+                            builder,
+                        );
+
+                        let instance = GarbledInstance::from(res);
+                        let wide_labels = info.shares.iter().map(|x| x.0).collect_vec();
+                        let tables = GarbledWideLabelTable::build_all(
+                            &wide_labels,
+                            &instance.input_wire_values,
+                        );
+                        let tables_hash = GarbledWideLabelTable::aggregate_hash(&tables);
+                        if tables_hash != commits.garbling_table_commits[index] {
+                            error!("regarbling failed, wide label table hash not equal");
+                            return Err(());
+                        }
+
+                        let regarbling_first_commit = CommitPhaseOne::<H>::from_instance(&instance);
+                        if &regarbling_first_commit != first_commit {
+                            error!("regarbling failed, first commit not equal");
+                            return Err(());
+                        }
+
+                        Ok(())
+                    }
                 })
                 .collect::<Result<Vec<()>, ()>>()
         })?;

--- a/src/cut_and_choose/garbler.rs
+++ b/src/cut_and_choose/garbler.rs
@@ -7,6 +7,8 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+use ark_secp256k1::Fr;
+use itertools::Itertools;
 use rand::Rng;
 use rayon::{iter::IntoParallelRefIterator, prelude::*};
 use serde::{Deserialize, Serialize};
@@ -16,13 +18,18 @@ use tracing::info;
 use crate::sp1_soldering::{self, SolderingProof};
 use crate::{
     AESAccumulatingHash, AesNiHasher, GarbleMode, GarbledWire, S, WireId,
+    cac::vsss::{self, Polynomial},
     circuit::{
         CiphertextHandler, CircuitBuilder, CircuitInput, EncodeInput, StreamingMode,
         StreamingResult,
     },
     cut_and_choose::{
-        CiphertextCommit, Config, DefaultLabelCommitHasher, LabelCommit, LabelCommitHasher, Seed,
-        commit_label_with,
+        CiphertextCommit, Config, DefaultLabelCommitHasher, GarbledWideLabelTable, LabelCommit,
+        LabelCommitHasher, Seed, commit_label_with,
+        vsss::{
+            Canonical, FinalizeChallenge, FinalizedVsssInstance, OpenVsssInstance, VsssCommit,
+            transpose,
+        },
     },
 };
 
@@ -251,6 +258,267 @@ impl GarblerStage {
             Self::Generating { seeds } => seeds,
             _ => unreachable!(),
         }
+    }
+}
+
+pub type InstanceWideLabelLookup = Vec<GarbledWideLabelTable>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VsssGarbler<I: CircuitInput + Clone> {
+    stage: GarblerStage,
+    instances: Vec<GarbledInstance>,
+    pub config: Config<I>,
+    live_capacity: usize,
+    polynomials: Vec<vsss::Polynomial<Canonical<Fr>>>,
+    pub wide_label_tables: Vec<InstanceWideLabelLookup>,
+}
+
+impl<I> VsssGarbler<I>
+where
+    I: CircuitInput
+        + Clone
+        + Send
+        + Sync
+        + EncodeInput<GarbleMode<AesNiHasher, AESAccumulatingHash>>,
+    <I as CircuitInput>::WireRepr: Send,
+    I: 'static,
+{
+    /// Create garbled instances in parallel using the provided circuit builder function.
+    pub fn create<F>(mut rng: impl Rng, config: Config<I>, live_capacity: usize, builder: F) -> Self
+    where
+        F: Fn(
+                &mut StreamingMode<GarbleMode<AesNiHasher, AESAccumulatingHash>>,
+                &I::WireRepr,
+            ) -> WireId
+            + Send
+            + Sync
+            + Copy,
+    {
+        let mut x = 0;
+        let allocated = config.input().allocate(|| {
+            x += 1;
+            WireId(x)
+        });
+        let num_inputs = <I as CircuitInput>::collect_wire_ids(&allocated).len();
+
+        let polynomials = (0..num_inputs)
+            .chunks(8)
+            .into_iter()
+            .flat_map(|chunk| {
+                let num_bits = chunk.count();
+                let num_labels = 2u32.pow(num_bits as u32);
+                (0..num_labels)
+                    .map(|_| vsss::Polynomial::rand(&mut rng, config.to_finalize))
+                    .collect_vec()
+            })
+            .collect_vec();
+
+        let coeffs = polynomials
+            .iter()
+            .map(|polynomial| {
+                polynomial
+                    .shares(config.total)
+                    .into_iter()
+                    .map(|(_, share)| share)
+                    .collect_vec()
+            })
+            .collect_vec();
+
+        let instance_wide_labels = transpose(&coeffs);
+
+        let seeds = (0..config.total)
+            .map(|_| rng.r#gen())
+            .collect::<Box<[Seed]>>();
+
+        // Use optimized thread pool internally
+        let ret: Vec<_> = super::get_optimized_pool().install(|| {
+            seeds
+                .iter()
+                .zip(instance_wide_labels.iter())
+                .collect_vec()
+                .par_iter()
+                .enumerate()
+                .map(|(index, (garbling_seed, wide_labels))| {
+                    let inputs = config.input.clone();
+                    let hasher = AESAccumulatingHash::default();
+
+                    let span = tracing::info_span!("garble", instance = index);
+                    let _enter = span.enter();
+
+                    info!("Starting garbling of circuit (cut-and-choose)");
+
+                    let res: StreamingResult<
+                        GarbleMode<AesNiHasher, AESAccumulatingHash>,
+                        I,
+                        GarbledWire,
+                    > = CircuitBuilder::streaming_garbling(
+                        inputs,
+                        live_capacity,
+                        **garbling_seed,
+                        hasher,
+                        builder,
+                    );
+
+                    let instance = GarbledInstance::from(res);
+                    let tables =
+                        GarbledWideLabelTable::build_all(wide_labels, &instance.input_wire_values);
+
+                    (instance, tables)
+                })
+                .collect()
+        });
+
+        let (instances, wide_label_tables): (Vec<_>, Vec<_>) = ret.into_iter().unzip();
+
+        Self {
+            stage: GarblerStage::Generating { seeds },
+            instances,
+            live_capacity,
+            config,
+            polynomials: polynomials
+                .into_iter()
+                .map(Polynomial::to_canonical)
+                .collect(),
+            wide_label_tables,
+        }
+    }
+
+    /// Produce the `Commit₁` transcript for every garbled instance (spec Step 1.2).
+    pub fn commit<HHasher>(&self) -> VsssCommit<HHasher>
+    where
+        HHasher: LabelCommitHasher,
+    {
+        let secp = vsss::Secp256k1::new();
+
+        let polynomials = self
+            .polynomials
+            .iter()
+            .map(Polynomial::from_canonical)
+            .collect_vec();
+        let share_commits = polynomials
+            .iter()
+            .map(|x| x.share_commits(&secp, self.config.total).to_canonical())
+            .collect();
+        let polynomial_commits = polynomials
+            .iter()
+            .map(|x| x.coefficient_commits(&secp).to_canonical())
+            .collect();
+
+        let circuit_commits = self
+            .instances
+            .iter()
+            .map(|x| CommitPhaseOne::<HHasher>::from_instance(x))
+            .collect_vec();
+
+        let garbling_table_commits = self
+            .wide_label_tables
+            .iter()
+            .map(|x| GarbledWideLabelTable::aggregate_hash(x))
+            .collect();
+        VsssCommit {
+            circuit_commits,
+            share_commits,
+            polynomial_commits,
+            garbling_table_commits,
+        }
+    }
+
+    pub fn open_commit<F, CTH: 'static + Send + CiphertextHandler>(
+        &mut self,
+        mut indexes_to_finalize: Vec<FinalizeChallenge<CTH>>,
+        builder: F,
+    ) -> (Vec<OpenVsssInstance>, Vec<FinalizedVsssInstance>)
+    where
+        F: 'static
+            + Fn(&mut StreamingMode<GarbleMode<AesNiHasher, CTH>>, &I::WireRepr) -> WireId
+            + Send
+            + Sync
+            + Copy,
+        I: EncodeInput<GarbleMode<AesNiHasher, CTH>>,
+    {
+        let seeds = self
+            .stage
+            .next_stage(indexes_to_finalize.iter().map(|x| x.index).collect());
+
+        let shares = self
+            .polynomials
+            .iter()
+            .map(|x| x.from_canonical().shares(self.config.total))
+            .collect_vec();
+
+        let mut finalized_instance_data = Vec::new();
+        let mut opened_instance_data = Vec::new();
+
+        // TODO #37 Since at this point the number but finalization is no more than 7, we just run
+        // threads here, without rayon
+        seeds
+            .iter()
+            .enumerate()
+            .map(|(index, garbling_seed)| {
+                let pos = indexes_to_finalize.iter().position(|x| x.index == index);
+
+                if let Some(pos) = pos {
+                    let finalization_info = indexes_to_finalize.remove(pos);
+                    // not revealed.
+                    let ciphertext_handler = finalization_info.ciphertext_handler;
+
+                    let inputs = self.config.input.clone();
+                    let garbling_seed = *garbling_seed;
+
+                    let live_capacity = self.live_capacity;
+
+                    let garbling_thread = thread::spawn(move || {
+                        let _span =
+                            tracing::info_span!("regarble2send", instance = index).entered();
+
+                        info!("Starting");
+
+                        let _: StreamingResult<_, I, GarbledWire> =
+                            CircuitBuilder::<GarbleMode<AesNiHasher, _>>::streaming_garbling(
+                                inputs,
+                                live_capacity,
+                                garbling_seed,
+                                ciphertext_handler,
+                                builder,
+                            );
+                    });
+
+                    finalized_instance_data.push(FinalizedVsssInstance {
+                        index,
+                        wide_label_lookup: self.wide_label_tables[index].clone(),
+                        garbling_thread,
+                    });
+                } else {
+                    // reveal share
+                    let shares = shares
+                        .iter()
+                        .map(|x| {
+                            let share = x[index];
+                            assert_eq!(index, share.0); // sanity check
+                            Canonical(share.1)
+                        })
+                        .collect_vec();
+                    opened_instance_data.push(OpenVsssInstance {
+                        index,
+                        seed: *garbling_seed,
+                        shares,
+                    });
+                }
+            })
+            .collect_vec();
+        (opened_instance_data, finalized_instance_data)
+    }
+
+    /// Return a clone of the input garbled labels for a given instance.
+    pub fn input_labels_for(&self, index: usize) -> Vec<GarbledWire> {
+        self.instances[index].input_wire_values.clone()
+    }
+
+    pub fn wide_labels_for(&self, index: usize) -> Vec<Fr> {
+        self.polynomials
+            .iter()
+            .map(|x| x.from_canonical().shares(self.config.total)[index].1)
+            .collect_vec()
     }
 }
 

--- a/src/cut_and_choose/groth16.rs
+++ b/src/cut_and_choose/groth16.rs
@@ -1,5 +1,6 @@
 //! Groth16-specific wrappers around the generic cut-and-choose API so callers
 //! can mirror the protocol described in `docs/gsv_spec.md` with minimal glue.
+use ark_secp256k1::Fr;
 #[cfg(feature = "sp1-soldering")]
 use garbled_groth16::{EvaluatedCompressedG1Wires, EvaluatedCompressedG2Wires, EvaluatedFrWires};
 use rand::Rng;
@@ -14,6 +15,7 @@ use crate::{
     cut_and_choose::{
         self as generic, CiphertextCommit, CiphertextHandlerProvider, CiphertextSourceProvider,
         ConsistencyError, DefaultLabelCommitHasher, GarblerStage,
+        vsss::{FinalizeChallenge, FinalizedVsssInstance, OpenVsssInstance, VsssCommit},
     },
     garbled_groth16::{self, PublicParams},
 };
@@ -21,6 +23,72 @@ use crate::{
 pub type Config = generic::Config<garbled_groth16::GarblerCompressedInput>;
 
 pub const DEFAULT_CAPACITY: usize = 150_000;
+
+/// Groth16-specific wrapper preserving the existing API while delegating
+/// to the generic cut-and-choose implementation.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VsssGarbler {
+    inner: generic::VsssGarbler<garbled_groth16::GarblerCompressedInput>,
+}
+
+impl VsssGarbler {
+    pub fn create(rng: impl Rng, config: Config) -> Self {
+        let inner = generic::VsssGarbler::create(
+            rng,
+            config,
+            DEFAULT_CAPACITY,
+            garbled_groth16::verify_compressed,
+        );
+        Self { inner }
+    }
+
+    pub fn from_inner(
+        inner: generic::VsssGarbler<garbled_groth16::GarblerCompressedInput>,
+    ) -> Self {
+        Self { inner }
+    }
+
+    pub fn inner(&mut self) -> &mut generic::VsssGarbler<garbled_groth16::GarblerCompressedInput> {
+        &mut self.inner
+    }
+
+    pub fn commit<HHasher>(&self) -> VsssCommit<HHasher>
+    where
+        HHasher: LabelCommitHasher,
+    {
+        // todo: also commit to the projective of the false output value
+
+        self.inner.commit::<HHasher>()
+    }
+
+    pub fn open_commit<CTH: 'static + Send + CiphertextHandler>(
+        &mut self,
+        indexes_to_finalize: Vec<FinalizeChallenge<CTH>>,
+    ) -> (Vec<OpenVsssInstance>, Vec<FinalizedVsssInstance>) {
+        self.inner
+            .open_commit(indexes_to_finalize, garbled_groth16::verify_compressed)
+    }
+
+    pub fn prepare_input_labels(
+        &self,
+        public_params: PublicParams,
+        challenge_proof: garbled_groth16::SnarkProof,
+        index: usize,
+    ) -> EvaluatorCaseInput {
+        let input = garbled_groth16::EvaluatorCompressedInput::new(
+            public_params.clone(),
+            challenge_proof.clone(),
+            self.inner.config.input().vk.clone(),
+            self.inner.input_labels_for(index),
+        );
+
+        EvaluatorCaseInput { index, input }
+    }
+
+    pub fn wide_labels_for(&self, index: usize) -> Vec<Fr> {
+        self.inner.wide_labels_for(index)
+    }
+}
 
 /// Groth16-specific wrapper preserving the existing API while delegating
 /// to the generic cut-and-choose implementation.

--- a/src/cut_and_choose/mod.rs
+++ b/src/cut_and_choose/mod.rs
@@ -20,11 +20,13 @@ use crate::{S, circuit::CircuitInput};
 pub mod ciphertext_repository;
 pub mod evaluator;
 pub mod garbler;
+pub mod vsss;
+pub mod wide_garbling;
 
 pub use ciphertext_repository::*;
 pub use evaluator::*;
 pub use garbler::*;
-
+pub use wide_garbling::*;
 pub mod groth16;
 
 pub type Seed = u64;
@@ -97,7 +99,7 @@ pub(crate) fn write_commit_hex(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt:
 /// evaluation set selected during Step 2 (challenging).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config<I: CircuitInput> {
-    total: usize,
+    pub total: usize,
     to_finalize: usize,
     input: I,
 }

--- a/src/cut_and_choose/tests.rs
+++ b/src/cut_and_choose/tests.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crossbeam::channel;
+use itertools::Itertools;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
@@ -12,6 +13,7 @@ use crate::{
         CiphertextHandler, CircuitContext, EncodeInput, EvaluateMode, FALSE_WIRE, TRUE_WIRE,
         ciphertext_source, modes::CircuitMode,
     },
+    cut_and_choose::vsss::{FinalizeChallenge, encode_input},
     gadgets::bn254::fq6::Fq6,
     hashers::GateHasher,
 };
@@ -46,7 +48,19 @@ where
 #[derive(Clone)]
 struct OneBitEvaluatorInput {
     bit: bool,
-    label: GarbledWire,
+    label: S,
+}
+impl OneBitEvaluatorInput {
+    fn from_evaluated_inputs(evaluated_inputs: &[EvaluatedWire]) -> Option<Self> {
+        if evaluated_inputs.len() != 1 {
+            return None;
+        }
+
+        Some(Self {
+            bit: evaluated_inputs[0].value,
+            label: evaluated_inputs[0].active_label,
+        })
+    }
 }
 
 impl CircuitInput for OneBitEvaluatorInput {
@@ -65,7 +79,7 @@ impl<H: GateHasher, SRC: ciphertext_source::CiphertextSource> EncodeInput<Evalua
     for OneBitEvaluatorInput
 {
     fn encode(&self, repr: &Self::WireRepr, cache: &mut EvaluateMode<H, SRC>) {
-        let ew = EvaluatedWire::new_from_garbled(&self.label, self.bit);
+        let ew = EvaluatedWire::new(self.label, self.bit);
         cache.feed_wire(*repr, ew);
     }
 }
@@ -180,11 +194,11 @@ fn cut_and_choose_one_bit_e2e() {
         // Build both true and false evaluator inputs
         let e_true = OneBitEvaluatorInput {
             bit: true,
-            label: input_labels[0].clone(),
+            label: input_labels[0].select(true),
         };
         let e_false = OneBitEvaluatorInput {
             bit: false,
-            label: input_labels[0].clone(),
+            label: input_labels[0].select(false),
         };
 
         cases_true.push(EvaluatorCaseInput {
@@ -213,6 +227,132 @@ fn cut_and_choose_one_bit_e2e() {
     for (_idx, out) in results_false {
         assert!(!out.value, "output should equal input (false)");
         // Output label consistency is already checked in evaluate_from_saved_all_with_consistency
+    }
+}
+
+#[test_log::test]
+fn cut_and_choose_one_bit_e2e_vsss() {
+    const CAPACITY: usize = 1000;
+    // Deterministic RNG for reproducibility
+    let mut rng = ChaCha20Rng::seed_from_u64(1234);
+
+    let total = 5usize;
+    let finalize = 2usize;
+
+    // Garbler creates all instances
+    let cfg_g = Config::new(total, finalize, OneBitGarblerInput);
+    let mut garbler = VsssGarbler::create(&mut rng, cfg_g, CAPACITY, one_bit_circuit);
+
+    // First phase: commit without nonce
+    let commits = garbler.commit::<DefaultLabelCommitHasher>();
+
+    // Evaluator chooses which instances to finalize with first commits
+    let cfg_e = Config::new(total, finalize, OneBitGarblerInput);
+    let mut evaluator: Evaluator<OneBitGarblerInput> =
+        Evaluator::create_vsss(&mut rng, cfg_e, commits);
+
+    // Todo: check vsss polynomial
+    // todo: add Ci commits
+
+    let finalize_indices: Vec<usize> = evaluator.finalized_indexes().to_vec();
+
+    // Build channels for finalized instances using iterator + unzip
+    let (senders, receivers): (Vec<_>, Vec<_>) = finalize_indices
+        .iter()
+        .map(|&index| {
+            let (tx, rx) = channel::unbounded::<S>();
+            (
+                FinalizeChallenge {
+                    index,
+                    ciphertext_handler: tx,
+                },
+                (index, rx),
+            )
+        })
+        .unzip();
+
+    // todo: also _return_: the garbling tables of opened instances
+    let (opened_instance_data, finalized_instance_data) =
+        garbler.open_commit(senders, one_bit_circuit);
+
+    // Run regarbling checks and persist ciphertexts
+    let out_dir = PathBuf::from("target/cut_and_choose_test_simple");
+    let handler_provider =
+        FileCiphertextHandlerProvider::new(out_dir.clone(), None).expect("create sink provider");
+
+    let (wide_label_lookups, threads): (Vec<_>, Vec<_>) = finalized_instance_data
+        .into_iter()
+        .map(|x| ((x.index, x.wide_label_lookup), x.garbling_thread))
+        .unzip();
+
+    evaluator
+        .run_regarbling_vsss(
+            &opened_instance_data,
+            &receivers,
+            &handler_provider,
+            CAPACITY,
+            one_bit_circuit,
+            &wide_label_lookups,
+        )
+        .expect("regarbling ok");
+
+    for thread in threads {
+        thread.join().unwrap();
+    }
+
+    // Gather input labels for finalized instances
+    let mut test_cases = Vec::new();
+
+    for (idx, (_, wide_label_lookup)) in finalize_indices.into_iter().zip(wide_label_lookups.iter())
+    {
+        // garbler reveals instance[idx]
+
+        for bit_val in [false, true] {
+            // step 1: garbler determines desired circuit input
+            // E.g. OneBitEvaluatorInput
+            let input = OneBitEvaluatorInput {
+                bit: bit_val,
+                label: S::ZERO,
+            };
+
+            // garbler encodes it
+            let encoded = encode_input(&input);
+
+            // translate input labels to wide labels
+            let wide_labels = garbler
+                .wide_labels_for(idx)
+                .chunks(256)
+                .into_iter()
+                .zip(encoded.chunks(8))
+                .map(|(wide_labels, bit_vals)| {
+                    let wide_label_idx = bit_vals.iter().fold(0, |acc, &val| acc * 2 + val as u8);
+                    wide_labels[wide_label_idx as usize]
+                })
+                .collect_vec();
+
+            let evaluated_wires = wide_labels
+                .iter()
+                .zip(wide_label_lookup.iter())
+                .flat_map(|(wide_label, wide_label_lookup)| {
+                    wide_label_lookup.lookup_evaluated_wires(wide_label)
+                })
+                .collect_vec();
+
+            let input = OneBitEvaluatorInput::from_evaluated_inputs(&evaluated_wires)
+                .expect("input should be valid");
+
+            test_cases.push((bit_val, EvaluatorCaseInput { index: idx, input }));
+        }
+    }
+
+    let (expected, test_cases): (Vec<_>, Vec<_>) = test_cases.into_iter().unzip();
+
+    let results = evaluator
+        .evaluate_from(&out_dir, test_cases, CAPACITY, one_bit_circuit)
+        .expect("consistency checks should pass for true inputs");
+
+    for (expected, (_, out)) in expected.iter().zip(results.iter()) {
+        assert_eq!(out.value, *expected, "output should equal expected");
     }
 }
 

--- a/src/cut_and_choose/vsss.rs
+++ b/src/cut_and_choose/vsss.rs
@@ -1,0 +1,126 @@
+use std::thread::JoinHandle;
+
+use ark_secp256k1::{Fr, Projective};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use crossbeam::channel;
+use itertools::Itertools;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{
+    AesNiHasher, CommitPhaseOne, LabelCommitHasher, S, WireId,
+    cac::vsss::{PolynomialCommits, ShareCommits},
+    circuit::{CiphertextHandler, CircuitMode, EncodeInput, EvaluateMode, ciphertext_source},
+    cut_and_choose::{GarbledWideLabelTable, InstanceWideLabelLookup, Seed},
+    hashers::DefaultLabelCommitHasher,
+};
+
+/// Messages emitted by the Garbler during Setup (spec Steps 1–4).
+pub enum SetupBroadcast<HHasher: LabelCommitHasher> {
+    Commit(VsssCommit<HHasher>),
+    OpenInstances(Vec<OpenVsssInstance>, Vec<(usize, InstanceWideLabelLookup)>),
+    Assert(usize, Vec<Canonical<Fr>>),
+}
+
+/// Messages emitted by the Evaluator during Setup.
+pub enum SetupResponse<CTH: 'static + Send + CiphertextHandler> {
+    /// Step 2 — finalization challenge specifying the evaluation set plus ciphertext handlers.
+    FinalizeChallenge(Vec<FinalizeChallenge<CTH>>),
+}
+
+pub struct FinalizeChallenge<CTH: 'static + Send + CiphertextHandler> {
+    pub index: usize,
+    pub ciphertext_handler: CTH,
+}
+
+pub struct VsssStreamReceivers {
+    pub index: usize,
+    pub ciphertext_receiver: channel::Receiver<S>,
+}
+
+// A hacky way to get the binary representation of an input
+pub fn encode_input<T>(val: &T) -> Vec<bool>
+where
+    T: EncodeInput<EvaluateMode<AesNiHasher, ciphertext_source::DummySource>>,
+{
+    // EvaluateMode<AesNiHasher, SRC>{}
+    let mut dummy_evaluate_mode = EvaluateMode::<AesNiHasher, ciphertext_source::DummySource>::new(
+        0,
+        S::ZERO,
+        S::ZERO,
+        ciphertext_source::DummySource,
+    );
+    let mut x = WireId::MIN.0;
+    let allocated = val.allocate(|| {
+        dummy_evaluate_mode.allocate_wire(1);
+
+        let ret = WireId(x);
+        x += 1;
+        ret
+    });
+    val.encode(&allocated, &mut dummy_evaluate_mode);
+    // (WireId::MIN.0..x).for_each(|_| dummy_evaluate_mode.allocate_wire(1));
+    (WireId::MIN.0..x)
+        .map(|i| {
+            dummy_evaluate_mode
+                .lookup_wire(WireId(i))
+                .expect("wire should have value")
+                .value
+        })
+        .collect_vec()
+}
+
+pub fn transpose<T: Clone>(m: &[Vec<T>]) -> Vec<Vec<T>> {
+    (0..m[0].len())
+        .map(|i| m.iter().map(|row| row[i].clone()).collect())
+        .collect()
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Canonical<T: CanonicalDeserialize + CanonicalSerialize>(pub T);
+
+impl<T: CanonicalSerialize + CanonicalDeserialize> Serialize for Canonical<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut bytes = Vec::new();
+        self.0
+            .serialize_compressed(&mut bytes)
+            .map_err(serde::ser::Error::custom)?;
+        serializer.serialize_bytes(&bytes)
+    }
+}
+
+impl<'de, T: CanonicalSerialize + CanonicalDeserialize> Deserialize<'de> for Canonical<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
+
+        Ok(Canonical(
+            T::deserialize_compressed(&bytes[..]).map_err(serde::de::Error::custom)?,
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(bound = "H: LabelCommitHasher")]
+pub struct VsssCommit<H: LabelCommitHasher = DefaultLabelCommitHasher> {
+    pub circuit_commits: Vec<CommitPhaseOne<H>>,
+    pub share_commits: Vec<ShareCommits<Canonical<Projective>>>,
+    pub polynomial_commits: Vec<PolynomialCommits<Canonical<Projective>>>,
+    pub garbling_table_commits: Vec<[u8; 32]>,
+}
+
+pub struct OpenVsssInstance {
+    pub index: usize,
+    pub seed: Seed,
+    pub shares: Vec<Canonical<Fr>>,
+}
+
+pub struct FinalizedVsssInstance {
+    pub index: usize,
+    pub wide_label_lookup: Vec<GarbledWideLabelTable>,
+    pub garbling_thread: JoinHandle<()>,
+}

--- a/src/cut_and_choose/wide_garbling.rs
+++ b/src/cut_and_choose/wide_garbling.rs
@@ -1,0 +1,172 @@
+use crate::{EvaluatedWire, GarbledWire, S};
+use ark_ff::{BigInteger, PrimeField};
+use ark_secp256k1::Fr;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
+const TAG_LEN: usize = 16;
+
+#[derive(Serialize, Deserialize, Hash, Debug, Clone)]
+pub struct GarbledWideLabelTable(Vec<Vec<u8>>);
+
+impl GarbledWideLabelTable {
+    pub fn build_all(byte_labels: &[Fr], bit_labels: &[GarbledWire]) -> Vec<Self> {
+        byte_labels
+            .chunks(256)
+            .zip(bit_labels.chunks(8))
+            .map(|(byte_labels, bit_labels)| GarbledWideLabelTable::new(byte_labels, bit_labels))
+            .collect()
+    }
+
+    fn new(byte_labels: &[Fr], bit_labels: &[GarbledWire]) -> Self {
+        assert_ne!(bit_labels.len(), 0);
+        assert_ne!(byte_labels.len(), 0);
+        assert_eq!(byte_labels.len(), 2usize.pow(bit_labels.len() as u32));
+
+        let table = byte_labels
+            .iter()
+            .enumerate()
+            .map(|(i, byte_label)| {
+                let bit_labels: Vec<u8> = (0..bit_labels.len())
+                    .map(|bit| {
+                        if ((i >> (bit_labels.len() - bit - 1)) & 1) == 0 {
+                            bit_labels[bit].label0
+                        } else {
+                            bit_labels[bit].label1
+                        }
+                    })
+                    .flat_map(|label| label.to_bytes())
+                    .chain(std::iter::repeat_n(0u8, TAG_LEN))
+                    .collect();
+
+                let mut blake_hash = blake3::Hasher::new();
+                let mut mask = (0..bit_labels.len()).map(|_| 0u8).collect_vec();
+                blake_hash.update(&byte_label.into_bigint().to_bytes_le());
+                blake_hash.finalize_xof().fill(&mut mask);
+
+                bit_labels
+                    .iter()
+                    .zip(mask.iter())
+                    .map(|(c, m)| c ^ m)
+                    .collect_vec()
+            })
+            .collect();
+        GarbledWideLabelTable(table)
+    }
+
+    pub fn aggregate_hash(tables: &[Self]) -> [u8; 32] {
+        // calculate a hash over all the wide label lookup tables
+        let mut hasher = blake3::Hasher::new();
+        for table in tables.iter() {
+            let bytes = table.0.iter().flatten().copied().collect_vec();
+            hasher.update(&bytes);
+        }
+        let hash = hasher.finalize();
+        *hash.as_bytes()
+    }
+
+    pub fn lookup(&self, wide_label: &Fr) -> Vec<S> {
+        self.lookup_evaluated_wires(wide_label)
+            .iter()
+            .map(|evaluated_wire| evaluated_wire.active_label)
+            .collect_vec()
+    }
+
+    pub fn lookup_index(&self, wide_label: &Fr) -> usize {
+        self.lookup_evaluated_wires_and_index(wide_label).0
+    }
+
+    pub fn lookup_evaluated_wires(&self, wide_label: &Fr) -> Vec<EvaluatedWire> {
+        self.lookup_evaluated_wires_and_index(wide_label).1
+    }
+
+    pub fn lookup_evaluated_wires_and_index(&self, wide_label: &Fr) -> (usize, Vec<EvaluatedWire>) {
+        self.0
+            .iter()
+            .enumerate()
+            .find_map(|(wide_label_idx, ciphertext)| {
+                let label_count = self.0.len().ilog2();
+                assert_eq!(ciphertext.len(), label_count as usize * 16 + TAG_LEN);
+
+                let mut mask = vec![0u8; ciphertext.len()];
+                let mut blake_hash = blake3::Hasher::new();
+                blake_hash.update(&wide_label.into_bigint().to_bytes_le());
+                blake_hash.finalize_xof().fill(&mut mask[..]);
+
+                let decrypted = ciphertext
+                    .iter()
+                    .zip(mask.iter())
+                    .map(|(c, m)| c ^ m)
+                    .collect_vec();
+
+                let (labels, tag) = decrypted.split_at(decrypted.len() - TAG_LEN);
+
+                let successful_decryption = tag.iter().all(|x| *x == 0);
+
+                successful_decryption.then_some((
+                    wide_label_idx,
+                    labels
+                        .chunks(16)
+                        .enumerate()
+                        .map(|(bit_idx, chunk)| {
+                            let label = S::from_bytes(
+                                chunk.try_into().expect("should be exactly 16 items"),
+                            );
+                            let bit_value =
+                                ((wide_label_idx >> (label_count as usize - bit_idx - 1)) & 1) == 1;
+                            EvaluatedWire::new(label, bit_value)
+                        })
+                        .collect_vec(),
+                ))
+            })
+            .expect("Failed to decrypt wide label lookup table with the given key")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_ff::UniformRand;
+    use rand::thread_rng;
+
+    use crate::Delta;
+
+    use super::*;
+
+    #[test]
+    fn test_garbled_wide_label_table_lookup() {
+        let mut rng = thread_rng();
+
+        let delta = Delta::generate(&mut rng);
+
+        for num_bits in [2, 8] {
+            let num_labels = 2u32.pow(num_bits as u32);
+            let bit_labels = (0..num_bits)
+                .map(|_| GarbledWire::random(&mut rng, &delta))
+                .collect_vec();
+            let byte_labels = (0..num_labels).map(|_| Fr::rand(&mut rng)).collect_vec();
+
+            let table = GarbledWideLabelTable::new(&byte_labels, &bit_labels);
+
+            let expected_vals = (0..num_labels)
+                .map(|i| {
+                    (0..num_bits)
+                        .map(|bit| {
+                            if ((i >> (num_bits - bit - 1)) & 1) == 0 {
+                                EvaluatedWire::new(bit_labels[bit].label0, false)
+                            } else {
+                                EvaluatedWire::new(bit_labels[bit].label1, true)
+                            }
+                        })
+                        .collect_vec()
+                })
+                .collect_vec();
+
+            for (byte_label, expected_vals) in byte_labels.iter().zip(expected_vals.iter()) {
+                let recovered_bit_labels = table.lookup_evaluated_wires(byte_label);
+                assert_eq!(&recovered_bit_labels[..], &expected_vals[..]);
+            }
+
+            println!("table size: {}", table.0.iter().flatten().count());
+        }
+    }
+}

--- a/src/garbled_groth16.rs
+++ b/src/garbled_groth16.rs
@@ -669,6 +669,43 @@ impl EvaluatorCompressedInput {
             vk,
         }
     }
+
+    pub fn from_evaluated_inputs(
+        num_public_inputs: usize,
+        evaluated_wires: Vec<EvaluatedWire>,
+        vk: VerifyingKey<Bn254>,
+    ) -> Self {
+        // public.len * Fr::N_BITS + (A: Fq::N_BITS + 1) + (B: 2*Fq::N_BITS + 1) + (C: Fq::N_BITS + 1)
+        let expected = (num_public_inputs * FrWire::N_BITS)
+            + (FqWire::N_BITS + 1)
+            + (2 * FqWire::N_BITS + 1)
+            + (FqWire::N_BITS + 1);
+        assert_eq!(evaluated_wires.len(), expected);
+
+        let mut it = evaluated_wires.into_iter();
+
+        EvaluatorCompressedInput {
+            public: (0..num_public_inputs)
+                .map(|_| EvaluatedFrWires(it.by_ref().take(FrWire::N_BITS).collect()))
+                .collect(),
+            a: EvaluatedCompressedG1Wires {
+                x: EvaluatedFrWires(it.by_ref().take(FqWire::N_BITS).collect()),
+                y_flag: it.by_ref().next().expect("a.y_flag wire"),
+            },
+            b: EvaluatedCompressedG2Wires {
+                x: [
+                    EvaluatedFrWires(it.by_ref().take(FqWire::N_BITS).collect()),
+                    EvaluatedFrWires(it.by_ref().take(FqWire::N_BITS).collect()),
+                ],
+                y_flag: it.by_ref().next().expect("b.y_flag wire"),
+            },
+            c: EvaluatedCompressedG1Wires {
+                x: EvaluatedFrWires(it.by_ref().take(FqWire::N_BITS).collect()),
+                y_flag: it.by_ref().next().expect("c.y_flag wire"),
+            },
+            vk,
+        }
+    }
 }
 
 impl CircuitInput for EvaluatorCompressedInput {


### PR DESCRIPTION
On top of #75, with a start on the docs based on #81.

A working test is available in `examples/groth16_cut_and_choose_vsss.rs`.

There is currently a lot of code duplication with the sp1 soldering approach. They should probably be unified in a tidier way, but I wanted to focus on getting this work before. Also some of the code & docs needs some general clean up. For example, I want to move some of the code out of the example into the evaluator impl.

One more small note: this implements vsss but not yet the adaptor sigs. Meaning it sends over the wide labels directly from the garbler to the evaluator instead of encoding to and decoding them from adaptor sigs. That's still todo, but should be straightforward since the low level code for that is already implemented and it doesn't need major protocol overhauls.